### PR TITLE
(v0.08) Kernel32: VGA graphics

### DIFF
--- a/source/kernel32/Makefile
+++ b/source/kernel32/Makefile
@@ -16,7 +16,7 @@ all: kernel32
 kernel32: $(TARGET_BIN)
 
 $(TARGET_BIN):
-	cargo +nightly build --release --manifest-path ../../Cargo.toml -Z json-target-spec
+	cargo +nightly build --release --manifest-path ../../Cargo.toml --target ../../.cargo/i386.json -Z json-target-spec
 	$(OBJCOPY) -O binary $(CARGO_OUTPUT) $(TARGET_BIN)
 
 # Очистка

--- a/source/kernel32/main.rs
+++ b/source/kernel32/main.rs
@@ -10,10 +10,73 @@ mod shell;
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     vga::clear_screen();
-    vga::print_str("Welcome, Realix v0.07 with Rust kernel!\n", vga::Color::Cyan);
+    
+    draw_logo();
+    
+    for _ in 0..12 {
+        vga::put_char(b'\n', vga::Color::Black);
+    }
+    
+    vga::print_str("  Welcome to Realix v0.07 - Rust Kernel\n", vga::Color::Cyan);
+    vga::print_str("  Press any key to enter shell...", vga::Color::LightGray);
+    
+    keyboard::read_key_blocking();
+    
+    vga::clear_screen();
+    vga::print_str("Welcome to Realix shell!\n", vga::Color::Cyan);
     shell::run();
     loop {
         unsafe { core::arch::asm!("hlt"); }
+    }
+}
+
+fn draw_logo() {
+    let block: u8 = 0xDB;
+    
+    let colors = [
+        vga::Color::Red,
+        vga::Color::Yellow,
+        vga::Color::Green,
+        vga::Color::Cyan,
+        vga::Color::Blue,
+        vga::Color::Magenta,
+    ];
+    
+    let letters: [[[u8; 6]; 8]; 6] = [
+        // R
+        [[1,1,1,1,0,0],[1,0,0,1,0,0],[1,0,0,1,0,0],[1,1,1,1,0,0],
+         [1,0,0,1,0,0],[1,0,0,1,0,0],[1,0,0,1,0,0],[1,0,0,1,0,0]],
+        // E
+        [[1,1,1,1,1,0],[1,0,0,0,0,0],[1,0,0,0,0,0],[1,1,1,1,0,0],
+         [1,0,0,0,0,0],[1,0,0,0,0,0],[1,0,0,0,0,0],[1,1,1,1,1,0]],
+        // A
+        [[0,1,1,1,0,0],[1,0,0,0,1,0],[1,0,0,0,1,0],[1,1,1,1,1,0],
+         [1,0,0,0,1,0],[1,0,0,0,1,0],[1,0,0,0,1,0],[1,0,0,0,1,0]],
+        // L
+        [[1,0,0,0,0,0],[1,0,0,0,0,0],[1,0,0,0,0,0],[1,0,0,0,0,0],
+         [1,0,0,0,0,0],[1,0,0,0,0,0],[1,0,0,0,0,0],[1,1,1,1,1,0]],
+        // I
+        [[0,1,1,1,0,0],[0,0,1,0,0,0],[0,0,1,0,0,0],[0,0,1,0,0,0],
+         [0,0,1,0,0,0],[0,0,1,0,0,0],[0,0,1,0,0,0],[0,1,1,1,0,0]],
+        // X
+        [[1,0,0,0,1,0],[0,1,0,1,0,0],[0,0,1,0,0,0],[0,0,1,0,0,0],
+         [0,0,1,0,0,0],[0,1,0,1,0,0],[1,0,0,0,1,0],[1,0,0,0,1,0]],
+    ];
+    
+    let start_x = 4;
+    let start_y = 2;
+    
+    for (li, letter) in letters.iter().enumerate() {
+        let color = colors[li % colors.len()];
+        let offset_x = start_x + li * 7;
+        
+        for (row, line) in letter.iter().enumerate() {
+            for (col, &pixel) in line.iter().enumerate() {
+                if pixel == 1 {
+                    vga::write_char_at(start_y + row, offset_x + col, block, color);
+                }
+            }
+        }
     }
 }
 

--- a/source/kernel32/main.rs
+++ b/source/kernel32/main.rs
@@ -5,6 +5,7 @@ use core::panic::PanicInfo;
 mod vga;
 mod keyboard;
 mod shell;
+mod matrix;
 
 #[link_section = ".text.entry"]
 #[no_mangle]

--- a/source/kernel32/matrix.rs
+++ b/source/kernel32/matrix.rs
@@ -1,0 +1,81 @@
+use crate::vga;
+
+pub fn run() {
+    vga::clear_screen();
+    
+    let mut drops: [usize; 80] = [0; 80];
+    
+    // Инициализация: капли на разной высоте
+    for col in 0..80 {
+        drops[col] = (col * 7 + 3) % 25;
+    }
+    
+    loop {
+        // Отрисовка одного кадра
+        for col in 0..80 {
+            let y = drops[col];
+            
+            // Белая голова
+            vga::write_char_at(y, col, random_sym(col, y), vga::Color::White);
+            
+            // Зелёный шлейф выше
+            if y > 0 {
+                vga::write_char_at(y - 1, col, random_sym(col, y - 1), vga::Color::Green);
+            }
+            
+            // Тёмный хвост ещё выше
+            if y >= 2 {
+                vga::write_char_at(y - 2, col, random_sym(col, y - 2), vga::Color::DarkGray);
+            }
+            
+            // Стираем всё что выше хвоста
+            if y >= 3 {
+                vga::write_char_at(y - 3, col, b' ', vga::Color::Black);
+            }
+            
+            // Двигаем каплю вниз
+            drops[col] += 1;
+            
+            // Если достигла дна — сбрасываем наверх
+            if drops[col] >= 25 {
+                for r in 0..25 {
+                    vga::write_char_at(r, col, b' ', vga::Color::Black);
+                }
+                drops[col] = 0;
+            }
+        }
+        
+        // Задержка для плавности
+        for _ in 0..20000000 {
+            unsafe { core::arch::asm!("nop"); }
+        }
+        
+        // Выход по любой клавише кроме Enter
+        if let Some(_key) = check_key() {
+            break;
+        }
+    }
+    
+    vga::clear_screen();
+}
+
+fn random_sym(col: usize, row: usize) -> u8 {
+    let n = col.wrapping_mul(17).wrapping_add(row.wrapping_mul(31));
+    let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890@#$%&*";
+    chars[n % chars.len()]
+}
+
+fn check_key() -> Option<u8> {
+    unsafe {
+        let s: u8;
+        core::arch::asm!("in al, 0x64", out("al") s);
+        if s & 1 != 0 && s & 0x20 == 0 {
+            let sc: u8;
+            core::arch::asm!("in al, 0x60", out("al") sc);
+            if sc & 0x80 == 0 && sc != 0x1C {
+                return Some(b'q');
+            }
+        }
+        None
+    }
+}

--- a/source/kernel32/shell.rs
+++ b/source/kernel32/shell.rs
@@ -17,6 +17,11 @@ pub fn run() {
 
 fn execute(input: &str) {
     match input {
+	"matrix" => {
+            vga::print_str("Entering Matrix... (press any key to exit)\n", Color::Green);
+            crate::matrix::run();
+        }
+
         "help" => {
             vga::print_str("Commands:\n", Color::Cyan);
             vga::print_str("  help     - Show this manual\n", Color::LightGray);
@@ -25,6 +30,7 @@ fn execute(input: &str) {
             vga::print_str("  meminfo  - Show memory info\n", Color::LightGray);
             vga::print_str("  reboot   - Reboot PC\n", Color::LightGray);
             vga::print_str("  shutdown - Power off PC\n", Color::LightGray);
+	    vga::print_str("  matrix   - Matrix rain animation\n", Color::LightGray);	
         }
         "clear" => {
             vga::clear_screen();

--- a/source/kernel32/vga.rs
+++ b/source/kernel32/vga.rs
@@ -119,3 +119,15 @@ pub fn backspace() {
         update_cursor();
     }
 }
+
+pub fn write_char_at(row: usize, col: usize, byte: u8, color: Color) {
+    if row >= VGA_HEIGHT || col >= VGA_WIDTH {
+        return;
+    }
+    let offset = (row * VGA_WIDTH + col) * 2;
+    unsafe {
+        let vga_ptr = 0xB8000 as *mut u8;
+        vga_ptr.add(offset).write_volatile(byte);
+        vga_ptr.add(offset + 1).write_volatile(color as u8);
+    }
+}


### PR DESCRIPTION
## Color REALIX Boot Logo

Added a colorful ASCII-art "REALIX" logo displayed on kernel startup before the shell.

## Kernel32 Boot Logo

<img width="718" height="454" alt="realix_logo" src="https://github.com/user-attachments/assets/4ceb5f44-a5ae-4f9c-a616-c87e9f51f197" />

### Changes:
- Added `vga::write_char_at(row, col, char, color)` — writes character at specific position without moving cursor
- Logo drawn using CP437 block character (0xDB) in 6 rainbow colors
- 8x6 pixel font for each letter (R, E, A, L, I, X)
- Press any key to continue to shell

## MATRIX, haha :)

<img width="716" height="398" alt="Снимок экрана_20260623_231347" src="https://github.com/user-attachments/assets/9a35f09b-4a14-4cfa-a1a3-ad058c60f81c" />