### PR TITLE
Add Kernel16 CLI improvements and debug tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.20)
+project(Realix NONE)
+
+set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/source")
+set(BUILD_OUT "${CMAKE_CURRENT_BINARY_DIR}")
+
+set(BOOTIX_BIN "${BUILD_OUT}/bootix.bin")
+set(INITRIX_BIN "${BUILD_OUT}/initrix.bin")
+set(KERNEL_BIN "${BUILD_OUT}/kernel.bin")
+set(REALIX_IMG "${BUILD_OUT}/realix.img")
+
+find_program(NASM nasm REQUIRED)
+find_program(DD dd REQUIRED)
+find_program(MFORMAT mformat REQUIRED)
+find_program(MCOPY mcopy REQUIRED)
+
+find_program(QEMU
+    NAMES qemu-system-i386 qemu-system-x86_64
+)
+
+file(GLOB_RECURSE ASM_SOURCES CONFIGURE_DEPENDS "${SRC_DIR}/*.asm")
+
+function(assemble_bin target source output)
+    add_custom_command(
+        OUTPUT "${output}"
+        COMMAND "${NASM}" -f bin "-i${SRC_DIR}/" "${SRC_DIR}/${source}" -o "${output}"
+        DEPENDS ${ASM_SOURCES}
+        VERBATIM
+        COMMENT "Building ${target}"
+    )
+endfunction()
+
+assemble_bin(bootix  "bootloader/bootix.asm"  "${BOOTIX_BIN}")
+assemble_bin(initrix "bootloader/initrix.asm" "${INITRIX_BIN}")
+assemble_bin(kernel  "kernel16/kernel.asm"    "${KERNEL_BIN}")
+
+add_custom_command(
+    OUTPUT "${REALIX_IMG}"
+    COMMAND "${DD}" if=/dev/zero "of=${REALIX_IMG}" bs=512 count=2880 status=none
+    COMMAND "${MFORMAT}" -i "${REALIX_IMG}" -f 1440 ::
+    COMMAND "${DD}" "if=${BOOTIX_BIN}" "of=${REALIX_IMG}" conv=notrunc status=none
+    COMMAND "${MCOPY}" -i "${REALIX_IMG}" "${INITRIX_BIN}" "::INITRIX.BIN"
+    COMMAND "${MCOPY}" -i "${REALIX_IMG}" "${KERNEL_BIN}" "::KERNEL.BIN"
+    DEPENDS "${BOOTIX_BIN}" "${INITRIX_BIN}" "${KERNEL_BIN}"
+    VERBATIM
+    COMMENT "Creating realix.img"
+)
+
+add_custom_target(realix ALL DEPENDS "${REALIX_IMG}")
+add_custom_target(image DEPENDS "${REALIX_IMG}")
+
+if(QEMU)
+    add_custom_target(run
+        COMMAND "${QEMU}" -drive "file=${REALIX_IMG},format=raw,if=floppy"
+        DEPENDS realix
+        VERBATIM
+        USES_TERMINAL
+    )
+
+    add_custom_target(run-debug
+        COMMAND "${QEMU}"
+                -no-reboot
+                -no-shutdown
+                -d int,cpu_reset,guest_errors
+                -D "${BUILD_OUT}/qemu-debug.log"
+                -drive "file=${REALIX_IMG},format=raw,if=floppy"
+        DEPENDS realix
+        VERBATIM
+        USES_TERMINAL
+    )
+endif()
+
+message(STATUS "NASM: ${NASM}")
+message(STATUS "dd: ${DD}")
+message(STATUS "mformat: ${MFORMAT}")
+message(STATUS "mcopy: ${MCOPY}")
+message(STATUS "QEMU: ${QEMU}")
+message(STATUS "Image: ${REALIX_IMG}")

--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,62 @@
-# © Realix > Makefile
-# (28.03.26) v0.04
-# ================
+# Realix build file
+# Works on Linux, WSL and MSYS2.
 
-# Конфигурация
-ASM = nasm
-ASMFLAGS = -f bin -i $(SRC_DIR)
-SRC_DIR = source
-BUILD_DIR = build
+ASM ?= nasm
+QEMU ?= qemu-system-i386
+SRC_DIR := source
+BUILD_DIR := build
+ASMFLAGS := -f bin -i$(SRC_DIR)/
+ASM_SOURCES := $(shell find $(SRC_DIR) -name '*.asm')
 
-.PHONY: all floppy bootix initrix kernel run clean always
+BOOTIX_BIN := $(BUILD_DIR)/bootix.bin
+INITRIX_BIN := $(BUILD_DIR)/initrix.bin
+KERNEL_BIN := $(BUILD_DIR)/kernel.bin
+IMAGE := $(BUILD_DIR)/realix.img
 
-# Запуск по умолчанию
+.PHONY: all floppy image bootix initrix kernel run run-debug check clean dirs
+
 all: floppy
 
+floppy image: $(IMAGE)
 
-# Сборка образа диска (floppy)
-floppy: $(BUILD_DIR)/realix.img
+check:
+	@command -v $(ASM) >/dev/null || { echo "Missing assembler: $(ASM)"; exit 1; }
+	@command -v dd >/dev/null || { echo "Missing dd. Install coreutils."; exit 1; }
+	@command -v mformat >/dev/null || { echo "Missing mformat. Install mtools."; exit 1; }
+	@command -v mcopy >/dev/null || { echo "Missing mcopy. Install mtools."; exit 1; }
+	@echo "Build tools found."
 
-$(BUILD_DIR)/realix.img: bootix initrix kernel
-	dd if=/dev/zero of=$(BUILD_DIR)/realix.img bs=512 count=2880
-	mformat -i $(BUILD_DIR)/realix.img -f 1440 ::
-	dd if=$(BUILD_DIR)/bootix.bin of=$(BUILD_DIR)/realix.img conv=notrunc
-	mcopy -i $(BUILD_DIR)/realix.img $(BUILD_DIR)/initrix.bin "::initrix.bin"
-	mcopy -i $(BUILD_DIR)/realix.img $(BUILD_DIR)/kernel.bin "::kernel.bin"
+$(IMAGE): check $(BOOTIX_BIN) $(INITRIX_BIN) $(KERNEL_BIN)
+	dd if=/dev/zero of=$(IMAGE) bs=512 count=2880 status=none
+	mformat -i $(IMAGE) -f 1440 ::
+	dd if=$(BOOTIX_BIN) of=$(IMAGE) conv=notrunc status=none
+	mcopy -i $(IMAGE) $(INITRIX_BIN) "::INITRIX.BIN"
+	mcopy -i $(IMAGE) $(KERNEL_BIN) "::KERNEL.BIN"
+	@echo "Created $(IMAGE)"
 
+bootix: $(BOOTIX_BIN)
 
-# Сборка загрузчика (bin)
-bootix: $(BUILD_DIR)/bootix.bin
+$(BOOTIX_BIN): dirs $(ASM_SOURCES)
+	$(ASM) $(ASMFLAGS) $(SRC_DIR)/bootloader/bootix.asm -o $(BOOTIX_BIN)
 
-$(BUILD_DIR)/bootix.bin: always
-	$(ASM) $(ASMFLAGS) $(SRC_DIR)/bootloader/bootix.asm -o $(BUILD_DIR)/bootix.bin
+initrix: $(INITRIX_BIN)
 
+$(INITRIX_BIN): dirs $(ASM_SOURCES)
+	$(ASM) $(ASMFLAGS) $(SRC_DIR)/bootloader/initrix.asm -o $(INITRIX_BIN)
 
-# Сборка инициализатора (bin)
-initrix: $(BUILD_DIR)/initrix.bin
+kernel: $(KERNEL_BIN)
 
-$(BUILD_DIR)/initrix.bin: always
-	$(ASM) $(ASMFLAGS) $(SRC_DIR)/bootloader/initrix.asm -o $(BUILD_DIR)/initrix.bin
+$(KERNEL_BIN): dirs $(ASM_SOURCES)
+	$(ASM) $(ASMFLAGS) $(SRC_DIR)/kernel16/kernel.asm -o $(KERNEL_BIN)
 
+run: $(IMAGE)
+	$(QEMU) -drive file=$(IMAGE),format=raw,if=floppy
 
-# Сборка ядра (bin)
-kernel: $(BUILD_DIR)/kernel.bin
+run-debug: $(IMAGE)
+	$(QEMU) -no-reboot -no-shutdown -d int,cpu_reset,guest_errors -D $(BUILD_DIR)/qemu-debug.log -drive file=$(IMAGE),format=raw,if=floppy
 
-$(BUILD_DIR)/kernel.bin: always
-	$(ASM) $(ASMFLAGS) $(SRC_DIR)/kernel16/kernel.asm -o $(BUILD_DIR)/kernel.bin
-
-
-# Запуск собранного образа диска
-run: floppy
-	qemu-system-x86_64 -drive file=$(BUILD_DIR)/realix.img,format=raw,if=floppy
-
-
-# Подготовка к сборке
-always:
+dirs:
 	mkdir -p $(BUILD_DIR)
 
-
-# Очистка
 clean:
-	rm -rf $(BUILD_DIR)/*
+	rm -rf $(BUILD_DIR)

--- a/source/kernel16/console/console.asm
+++ b/source/kernel16/console/console.asm
@@ -1,0 +1,300 @@
+; Realix Kernel16 console
+; Keeps a small text scrollback buffer and can redraw it with PageUp/PageDown.
+
+bits 16
+
+CONSOLE_COLS         equ 80
+CONSOLE_ROWS         equ 25
+CONSOLE_BUFFER_LINES equ 100
+CONSOLE_PAGE_STEP    equ 5
+CONSOLE_ATTR         equ 0x07
+
+console_init:
+    push ax
+    push cx
+    push di
+
+    mov di, console_buffer
+    mov cx, CONSOLE_COLS * CONSOLE_BUFFER_LINES
+    mov al, ' '
+    rep stosb
+
+    mov word [console_line], 0
+    mov byte [console_col], 0
+    mov word [console_count], 1
+    mov word [console_view], 0
+
+    pop di
+    pop cx
+    pop ax
+    ret
+
+; Print AL and save it to the scrollback buffer.
+console_putc:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+
+    mov [console_char], al
+
+    cmp al, 0x0D
+    je .carriage_return
+
+    cmp al, 0x0A
+    je .line_feed
+
+    cmp byte [console_col], CONSOLE_COLS
+    jb .store_char
+    call console_newline_internal
+
+.store_char:
+    mov ax, [console_line]
+    mov bx, CONSOLE_COLS
+    mul bx
+    mov di, console_buffer
+    add di, ax
+
+    xor ax, ax
+    mov al, [console_col]
+    add di, ax
+
+    mov al, [console_char]
+    mov [di], al
+
+    cmp word [console_view], 0
+    jne .after_display
+
+    mov ah, 0x0E
+    xor bx, bx
+    int 0x10
+
+.after_display:
+    inc byte [console_col]
+    cmp byte [console_col], CONSOLE_COLS
+    jb .done
+    call console_newline_internal
+    jmp .done
+
+.carriage_return:
+    cmp word [console_view], 0
+    jne .done
+    mov ah, 0x0E
+    xor bx, bx
+    int 0x10
+    jmp .done
+
+.line_feed:
+    call console_newline_internal
+    cmp word [console_view], 0
+    jne .done
+    mov al, 0x0A
+    mov ah, 0x0E
+    xor bx, bx
+    int 0x10
+
+.done:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+console_newline_internal:
+    push ax
+
+    mov byte [console_col], 0
+
+    mov ax, [console_line]
+    inc ax
+    cmp ax, CONSOLE_BUFFER_LINES
+    jb .line_ok
+    xor ax, ax
+
+.line_ok:
+    mov [console_line], ax
+
+    mov ax, [console_count]
+    cmp ax, CONSOLE_BUFFER_LINES
+    jae .clear_line
+    inc ax
+    mov [console_count], ax
+
+.clear_line:
+    call console_clear_current_line
+
+    pop ax
+    ret
+
+console_clear_current_line:
+    push ax
+    push bx
+    push cx
+    push di
+
+    mov ax, [console_line]
+    mov bx, CONSOLE_COLS
+    mul bx
+    mov di, console_buffer
+    add di, ax
+
+    mov cx, CONSOLE_COLS
+    mov al, ' '
+    rep stosb
+
+    pop di
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; PageUp: show older lines.
+console_page_up:
+    push ax
+
+    mov ax, [console_count]
+    cmp ax, 1
+    jbe .done
+    dec ax                         ; max view offset
+
+    mov [console_max_view], ax
+    mov ax, [console_view]
+    add ax, CONSOLE_PAGE_STEP
+    cmp ax, [console_max_view]
+    jbe .store
+    mov ax, [console_max_view]
+
+.store:
+    mov [console_view], ax
+    call console_redraw
+
+.done:
+    pop ax
+    ret
+
+; PageDown: show newer lines.
+console_page_down:
+    push ax
+
+    mov ax, [console_view]
+    cmp ax, CONSOLE_PAGE_STEP
+    ja .sub_step
+    xor ax, ax
+    jmp .store
+
+.sub_step:
+    sub ax, CONSOLE_PAGE_STEP
+
+.store:
+    mov [console_view], ax
+    call console_redraw
+
+    pop ax
+    ret
+
+; Return to live bottom view.
+console_to_bottom:
+    cmp word [console_view], 0
+    je .done
+    mov word [console_view], 0
+    call console_redraw
+.done:
+    ret
+
+console_redraw:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+
+    mov ax, [console_line]
+    sub ax, [console_view]
+    call console_wrap_ax
+    sub ax, CONSOLE_ROWS - 1
+    call console_wrap_ax
+    mov [console_draw_line], ax
+
+    mov ax, 0xB800
+    mov es, ax
+    xor di, di
+    mov dx, CONSOLE_ROWS
+
+.row_loop:
+    mov ax, [console_draw_line]
+    mov bx, CONSOLE_COLS
+    mul bx
+    mov si, console_buffer
+    add si, ax
+
+    mov cx, CONSOLE_COLS
+
+.col_loop:
+    lodsb
+    mov ah, CONSOLE_ATTR
+    stosw
+    loop .col_loop
+
+    mov ax, [console_draw_line]
+    inc ax
+    call console_wrap_ax
+    mov [console_draw_line], ax
+
+    dec dx
+    jnz .row_loop
+
+    mov ah, 0x02
+    xor bh, bh
+    mov dh, CONSOLE_ROWS - 1
+    mov dl, 0
+    cmp word [console_view], 0
+    jne .set_cursor
+    mov dl, [console_col]
+    cmp dl, CONSOLE_COLS
+    jb .set_cursor
+    mov dl, CONSOLE_COLS - 1
+
+.set_cursor:
+    int 0x10
+
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Wrap AX to 0..CONSOLE_BUFFER_LINES-1.
+console_wrap_ax:
+.wrap:
+    cmp ax, CONSOLE_BUFFER_LINES
+    jb .done
+    cmp ax, 0x8000
+    jae .negative
+    sub ax, CONSOLE_BUFFER_LINES
+    jmp .wrap
+
+.negative:
+    add ax, CONSOLE_BUFFER_LINES
+    jmp .wrap
+
+.done:
+    ret
+
+console_line:      dw 0
+console_count:     dw 1
+console_view:      dw 0
+console_max_view:  dw 0
+console_draw_line: dw 0
+console_col:       db 0
+console_char:      db 0
+
+console_buffer: times CONSOLE_COLS * CONSOLE_BUFFER_LINES db ' '

--- a/source/kernel16/debug/panic.asm
+++ b/source/kernel16/debug/panic.asm
@@ -1,0 +1,185 @@
+; Realix Kernel16 debug helpers
+; Basic real-mode panic screen and simple CPU exception handlers.
+
+bits 16
+
+; Install a few useful real-mode exception handlers.
+; This helps when the kernel crashes after it has already started.
+install_exception_handlers:
+    push ax
+    push es
+
+    xor ax, ax
+    mov es, ax
+    mov ax, cs
+
+    mov word [es:0x00 * 4], isr_divide_error
+    mov word [es:0x00 * 4 + 2], ax
+
+    mov word [es:0x03 * 4], isr_breakpoint
+    mov word [es:0x03 * 4 + 2], ax
+
+    mov word [es:0x04 * 4], isr_overflow
+    mov word [es:0x04 * 4 + 2], ax
+
+    mov word [es:0x05 * 4], isr_bounds
+    mov word [es:0x05 * 4 + 2], ax
+
+    mov word [es:0x06 * 4], isr_invalid_opcode
+    mov word [es:0x06 * 4 + 2], ax
+
+    mov word [es:0x0D * 4], isr_general_protection
+    mov word [es:0x0D * 4 + 2], ax
+
+    pop es
+    pop ax
+    ret
+
+; Manual panic for testing from shell command.
+debug_panic_manual:
+    mov si, panic_manual_msg
+    jmp exception_common
+
+; Manual divide-by-zero crash for testing the installed handler.
+debug_test_divzero:
+    xor ax, ax
+    div al
+    ret
+
+isr_divide_error:
+    mov si, panic_divide_msg
+    jmp exception_common
+
+isr_breakpoint:
+    mov si, panic_breakpoint_msg
+    jmp exception_common
+
+isr_overflow:
+    mov si, panic_overflow_msg
+    jmp exception_common
+
+isr_bounds:
+    mov si, panic_bounds_msg
+    jmp exception_common
+
+isr_invalid_opcode:
+    mov si, panic_invalid_opcode_msg
+    jmp exception_common
+
+isr_general_protection:
+    mov si, panic_gp_msg
+    jmp exception_common
+
+; Common panic screen.
+; If called as a CPU exception, stack contains IP, CS, FLAGS.
+; If called manually, those values are not meaningful, but the screen still helps.
+exception_common:
+    cli
+
+    push bp
+    mov bp, sp
+
+    push ax
+    push bx
+    push si
+    push ds
+
+    push cs
+    pop ds
+
+    mov [panic_message_ptr], si
+
+    ; Make sure we are in a visible text mode.
+    mov ax, 0x0003
+    int 0x10
+
+    mov si, panic_title
+    call print
+    call print_new_line
+
+    mov si, panic_reason
+    call print
+    mov si, [panic_message_ptr]
+    call print
+    call print_new_line
+
+    mov si, panic_ip
+    call print
+    mov ax, [ss:bp + 2]
+    call debug_print_hex16
+
+    mov si, panic_cs
+    call print
+    mov ax, [ss:bp + 4]
+    call debug_print_hex16
+
+    mov si, panic_flags
+    call print
+    mov ax, [ss:bp + 6]
+    call debug_print_hex16
+    call print_new_line
+
+    mov si, panic_hint_1
+    call print
+    call print_new_line
+    mov si, panic_hint_2
+    call print
+
+.halt:
+    hlt
+    jmp .halt
+
+; Print AX as four uppercase hexadecimal digits.
+debug_print_hex16:
+    push ax
+    push bx
+    push cx
+
+    mov bx, ax
+    mov cx, 4
+
+.next_digit:
+    rol bx, 4
+    mov al, bl
+    and al, 0x0F
+
+    cmp al, 9
+    jbe .digit
+    add al, 'A' - 10
+    jmp .print
+
+.digit:
+    add al, '0'
+
+.print:
+    push ax
+    push bx
+    mov ah, 0x0E
+    xor bx, bx
+    int 0x10
+    pop bx
+    pop ax
+
+    loop .next_digit
+
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+panic_message_ptr: dw 0
+
+panic_title:              db '*** REALIX KERNEL PANIC ***', 0
+panic_reason:             db 'Reason: ', 0
+panic_ip:                 db 'IP=0x', 0
+panic_cs:                 db ' CS=0x', 0
+panic_flags:              db ' FLAGS=0x', 0
+panic_hint_1:             db 'CPU halted to keep the error visible.', 0
+panic_hint_2:             db 'If this happened in QEMU, also check qemu-debug.log.', 0
+panic_manual_msg:         db 'Manual panic requested', 0
+panic_divide_msg:         db 'Divide error', 0
+panic_breakpoint_msg:     db 'Breakpoint', 0
+panic_overflow_msg:       db 'Overflow', 0
+panic_bounds_msg:         db 'BOUND range exceeded', 0
+panic_invalid_opcode_msg: db 'Invalid opcode', 0
+panic_gp_msg:             db 'General protection fault', 0

--- a/source/kernel16/io/print.asm
+++ b/source/kernel16/io/print.asm
@@ -18,7 +18,11 @@ print:
     test al, al   ; Достигнут ли конец строки?
     jz .done
 
+%ifdef KERNEL_CONSOLE
+    call console_putc
+%else
     int 0x10
+%endif
     jmp .next_char
 
 .done:

--- a/source/kernel16/io/print_nl.asm
+++ b/source/kernel16/io/print_nl.asm
@@ -1,21 +1,26 @@
-; © Realix > Print «\n\r»
+; © Realix > Print new line
 ; (14.06.26) v0.06
 ; ================
 
-; > Вывол символа «перевод строки» на экран (Текстовый режим)
+; > Print CR/LF on screen.
 print_new_line:
     push ax
     push bx
 
-    ; Настройка TTY mode, номера страницы и цвета
+%ifdef KERNEL_CONSOLE
+    mov al, 0x0D
+    call console_putc
+    mov al, 0x0A
+    call console_putc
+%else
     mov ah, 0x0E
     xor bx, bx
 
-    ; Вывод символа «\n\r»
     mov al, 0x0D
     int 0x10
     mov al, 0x0A
     int 0x10
+%endif
 
     pop bx
     pop ax

--- a/source/kernel16/io/print_reg.asm
+++ b/source/kernel16/io/print_reg.asm
@@ -26,8 +26,12 @@ print_reg:
 
 .print_char:
     pop ax        ; Достаём цифру из стека
+%ifdef KERNEL_CONSOLE
+    call console_putc
+%else
     mov ah, 0x0E  ; TTY mode (Вывод с прокруткой курсора)
     int 0x10
+%endif
     loop .print_char
 
 .done:

--- a/source/kernel16/kernel.asm
+++ b/source/kernel16/kernel.asm
@@ -11,6 +11,9 @@ org 0x0
 
 ; > Установка ядра
 kernel_start:
+    call console_init
+    call install_exception_handlers
+
 	mov si, msg_start_kernel
 	call print
 
@@ -37,9 +40,12 @@ main:
     jmp $
 
 ; Подключение модулей
+%define KERNEL_CONSOLE
+%include 'kernel16/console/console.asm'
 %include 'kernel16/io/print.asm'
 %include 'kernel16/io/print_nl.asm'
 %include 'kernel16/io/print_reg.asm'
+%include 'kernel16/debug/panic.asm'
 %include 'kernel16/shell/cli.asm'
 %include 'kernel16/shell/commands.asm'
 %include 'bios-api/memory/get_free.asm'

--- a/source/kernel16/shell/cli.asm
+++ b/source/kernel16/shell/cli.asm
@@ -1,141 +1,390 @@
-; © Realix > Command Line Interface
-; (13.06.26) v0.06
-; ø Вдохновлено @nyxmalware
-; ================
-; ❗️ Зависимости: kernel16/io/print.asm, kernel16/io/print_nl.asm
+; Realix Kernel16 CLI
+; Simple text command line for real mode.
 
-; Основные константы
+bits 16
+
 %include 'config.asm'
 
-; > Главный цикл CLI (Вызывается из ядра для обработки команд)
+HISTORY_SLOTS    equ 5
+HISTORY_LINE_LEN equ INPUT_BUFFER_LEN + 1
+
+; Main shell loop.
 run_cli:
     push si
 
 .prompt:
-    ; "Realix@User >> "
     mov si, prompt_sign
     call print
 
     call cli_input
 
-    ; Если ввод пустой, заново ждём ввод
     cmp byte [input_buffer], 0
     je .prompt
 
-    ; Выполнение команды
     mov si, input_buffer
     call execute_cmd
-
-    ; Перевод строки на экране
     call print_new_line
 
-    jnc .prompt
+    jmp .prompt
 
-.done:
-    pop si
-    ret
-
-
-; > Функция чтения строки
+; Read one line into input_buffer.
+;
+; Keys:
+;   Enter      submit
+;   Backspace  delete last character
+;   Up/Down    command history
+;   PageUp     scroll console up
+;   PageDown   scroll console down
+;   Esc/Ctrl+U clear current line
+;
+; Left/Right editing is disabled for now.
+; It needs prompt-boundary handling, otherwise the cursor can move before "Realix>".
 cli_input:
     push ax
     push bx
     push di
 
-    ; Счётчик введённых символов и указатель адреса буффера
     xor bx, bx
     mov di, input_buffer
+    mov byte [input_buffer], 0
+    mov byte [history_view], 0
 
 .input_loop:
-    ; Ожидание нажатия (ASCII > al)
     xor ah, ah
     int 0x16
 
-    ; ENTER > Проверка введённой строки
+    cmp al, 0
+    je .extended_key
+
+    cmp al, 0xE0
+    je .extended_key
+
     cmp al, ENTER_KEY
-    je .enter_pressed
-    
-    ; Backspace > Стирание последнего символа
+    je .enter
+
     cmp al, BACKSPACE_KEY
-    je .backspace_pressed
+    je .backspace
 
-    ; Проверка на переполнение
-    cmp bx, INPUT_BUFFER_LEN
-    jae input_buffer_overflow_error
+    cmp al, 0x1B            ; Esc
+    je .clear_line
 
-    ; Игнор управляющих символов
+    cmp al, 0x15            ; Ctrl+U
+    je .clear_line
+
     cmp al, 0x20
     jb .input_loop
 
-    ; Отображение символа на экране (Эхо)
-    mov ah, 0x0E
-    int 0x10
+    mov byte [history_view], 0
+    call console_to_bottom
 
-    ; Сохранение символа в буфер
+    cmp bx, INPUT_BUFFER_LEN
+    jae .buffer_full
+
     mov [di], al
     inc di
     inc bx
+    mov byte [di], 0
 
-    ; Возвращаемся в поток ввода
+    mov al, [di - 1]
+    call cli_print_char
+
     jmp .input_loop
 
-.backspace_pressed:
-    ; Проверка на пустой буффер
+.extended_key:
+    cmp ah, 0x48            ; Up
+    je .history_up
+
+    cmp ah, 0x50            ; Down
+    je .history_down
+
+    cmp ah, 0x49            ; PageUp
+    je .page_up
+
+    cmp ah, 0x51            ; PageDown
+    je .page_down
+
+    ; Left/Right/Home/End/Delete are ignored for now.
+    jmp .input_loop
+
+.history_up:
+    call history_prev
+    jmp .input_loop
+
+.history_down:
+    call history_next
+    jmp .input_loop
+
+.page_up:
+    call console_page_up
+    jmp .input_loop
+
+.page_down:
+    call console_page_down
+    jmp .input_loop
+
+.backspace:
+    mov byte [history_view], 0
+    call console_to_bottom
+
     test bx, bx
     jz .input_loop
-    
-    ; Стирание последнего символа из буфера
+
     dec di
     dec bx
     mov byte [di], 0
 
-    ; Визуальное стирание символа на экране
-    push bx
-    mov ah, 0x0E
-    xor bx, bx
-
-    mov al, 0x08
-    int 0x10
-    mov al, ' '
-    int 0x10
-    mov al, 0x08
-    int 0x10
-    pop bx
-
-    ; Возвращаемся в поток ввода
+    call cli_erase_char
     jmp .input_loop
 
-.enter_pressed:
-    call print_new_line
+.clear_line:
+    mov byte [history_view], 0
+    call console_to_bottom
+    call cli_clear_input
+    jmp .input_loop
 
-    ; Закрываем строку нуль-терминатором
+.buffer_full:
+    mov al, BEEP_CHAR
+    call cli_print_char
+    jmp .input_loop
+
+.enter:
+    call print_new_line
     mov byte [di], 0
+
+    cmp byte [input_buffer], 0
+    je .skip_save
+
+    call history_save
+
+.skip_save:
+    mov byte [history_view], 0
+
     pop di
     pop bx
     pop ax
     ret
 
+; Print AL through BIOS TTY.
+; Input echo is intentionally not written to the scrollback buffer.
+cli_print_char:
+    push ax
+    push bx
 
-input_buffer_overflow_error:
+    mov ah, 0x0E
+    xor bx, bx
+    int 0x10
+
+    pop bx
+    pop ax
+    ret
+
+; Visually erase one character from the screen.
+cli_erase_char:
+    push ax
+
+    mov al, 0x08
+    call cli_print_char
+    mov al, ' '
+    call cli_print_char
+    mov al, 0x08
+    call cli_print_char
+
+    pop ax
+    ret
+
+; Clear current input line.
+; Uses and updates BX as current length and DI as input pointer.
+cli_clear_input:
+    test bx, bx
+    jz .done
+
+.loop:
+    call cli_erase_char
+    dec di
+    dec bx
+    mov byte [di], 0
+    test bx, bx
+    jnz .loop
+
+.done:
+    mov di, input_buffer
+    ret
+
+; Save input_buffer to command history.
+history_save:
+    push ax
+    push bx
+    push cx
+    push si
+    push di
+
+    mov al, [history_next_slot]
+    call history_get_ptr
+    mov di, si
+    mov si, input_buffer
+    mov cx, HISTORY_LINE_LEN
+
+.copy_loop:
+    mov al, [si]
+    mov [di], al
+    inc si
+    inc di
+    test al, al
+    jz .copied
+    loop .copy_loop
+
+.copied:
+    mov al, [history_next_slot]
+    inc al
+    cmp al, HISTORY_SLOTS
+    jb .store_next
+    xor al, al
+
+.store_next:
+    mov [history_next_slot], al
+
+    mov al, [history_count]
+    cmp al, HISTORY_SLOTS
+    jae .done
+    inc al
+    mov [history_count], al
+
+.done:
+    pop di
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Go to older command.
+; Uses and updates BX/DI from cli_input.
+history_prev:
+    push ax
     push si
 
-    ; Вывод ошибки
-    call print_new_line
-    mov si, err_input_buffer_overflow
-	call print
+    cmp byte [history_count], 0
+    je .done
 
-    ; Сброс текущего ввода
-    xor bx, bx
+    mov al, [history_view]
+    cmp al, [history_count]
+    jae .show
+
+    inc al
+    mov [history_view], al
+
+.show:
+    call history_show
+
+.done:
+    pop si
+    pop ax
+    ret
+
+; Go to newer command, or clear line after newest command.
+; Uses and updates BX/DI from cli_input.
+history_next:
+    push ax
+    push si
+
+    cmp byte [history_view], 0
+    je .done
+
+    cmp byte [history_view], 1
+    jne .move_newer
+
+    mov byte [history_view], 0
+    call console_to_bottom
+    call cli_clear_input
+    jmp .done
+
+.move_newer:
+    dec byte [history_view]
+    call history_show
+
+.done:
+    pop si
+    pop ax
+    ret
+
+; Show command selected by history_view.
+; Uses and updates BX/DI from cli_input.
+history_show:
+    call console_to_bottom
+    call cli_clear_input
+
+    mov al, [history_next_slot]
+    mov dl, [history_view]
+
+.index_loop:
+    cmp dl, 0
+    je .index_ready
+
+    cmp al, 0
+    jne .dec_index
+    mov al, HISTORY_SLOTS
+
+.dec_index:
+    dec al
+    dec dl
+    jmp .index_loop
+
+.index_ready:
+    call history_get_ptr
+    call cli_load_history_line
+    ret
+
+; AL = history slot index.
+; Returns SI = pointer to slot.
+history_get_ptr:
+    push ax
+    push bx
+    push cx
+
+    xor ah, ah
+    mov bx, ax
+    mov cl, 6
+    shl bx, cl              ; index * 64
+    add bx, ax              ; index * 65
+
+    mov si, history_buffer
+    add si, bx
+
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Copy history line from DS:SI to input_buffer and echo it.
+; Updates BX and DI for cli_input.
+cli_load_history_line:
     mov di, input_buffer
+    xor bx, bx
+
+.loop:
+    mov al, [si]
+    mov [di], al
+    test al, al
+    jz .done
+
+    call cli_print_char
+
+    inc si
+    inc di
+    inc bx
+    cmp bx, INPUT_BUFFER_LEN
+    jb .loop
+
     mov byte [di], 0
 
-    pop si
-    jmp cli_input.enter_pressed
+.done:
+    ret
 
+prompt_sign: db 'Realix> ', 0
 
-; Сообщения и строки
-prompt_sign:               db 'Realix@User >> ', 0
-err_input_buffer_overflow: db '[!] The input buffer maximum is 64 symbols!', 0
+input_buffer: times HISTORY_LINE_LEN db 0
 
-; Переменные
-input_buffer: times 65 db 0
+history_count: db 0
+history_next_slot: db 0
+history_view:  db 0
+history_buffer: times HISTORY_SLOTS * HISTORY_LINE_LEN db 0

--- a/source/kernel16/shell/commands.asm
+++ b/source/kernel16/shell/commands.asm
@@ -1,9 +1,6 @@
-; © Realix > Shell Commands
-; (13.06.26) v0.06
-; ø Вдохновлено @nyxmalware
-; ================
-; ❗️ Зависимости: bios-api/memory (модуль)
-; TODO: Возвращение carry_flag при ошибке
+; Realix Kernel16 shell commands
+; Small BIOS-based commands for the 16-bit shell.
+; This file is included from kernel16/kernel.asm.
 
 ; Таблица команд (С названиями)
 align 2
@@ -15,6 +12,36 @@ cmd_table:
     dw .str_shutdown, cmd_shutdown
     dw .str_meminfo,  cmd_meminfo
     dw .str_echo,     cmd_echo
+    dw .str_ver,      cmd_ver
+    dw .str_about,    cmd_about
+    dw .str_beep,     cmd_beep
+    dw .str_time,     cmd_time
+    dw .str_date,     cmd_date
+    dw .str_calc,     cmd_calc
+    dw .str_key,      cmd_key
+    dw .str_ticks,    cmd_ticks
+    dw .str_rand,     cmd_rand
+    dw .str_len,      cmd_len
+    dw .str_upper,    cmd_upper
+    dw .str_lower,    cmd_lower
+    dw .str_reverse,  cmd_reverse
+    dw .str_wait,     cmd_wait
+    dw .str_cursor,   cmd_cursor
+    dw .str_screen,   cmd_screen
+    dw .str_uptime,   cmd_uptime
+    dw .str_hex,      cmd_hex
+    dw .str_ascii,    cmd_ascii
+    dw .str_repeat,   cmd_repeat
+    dw .str_history,  cmd_history
+    dw .str_boot,     cmd_boot
+    dw .str_segs,     cmd_segs
+    dw .str_mode3,    cmd_mode3
+    dw .str_mode50,   cmd_mode50
+    dw .str_banner,   cmd_banner
+    dw .str_fib,      cmd_fib
+    dw .str_panic,    cmd_panic
+    dw .str_divzero,  cmd_divzero
+    dw .str_halt,     cmd_halt
     dw 0, 0
 
 .str_help:     db 'help', 0
@@ -24,9 +51,39 @@ cmd_table:
 .str_shutdown: db 'shutdown', 0
 .str_meminfo:  db 'meminfo', 0
 .str_echo:     db 'echo', 0
+.str_ver:      db 'ver', 0
+.str_about:    db 'about', 0
+.str_beep:     db 'beep', 0
+.str_time:     db 'time', 0
+.str_date:     db 'date', 0
+.str_calc:     db 'calc', 0
+.str_key:      db 'key', 0
+.str_ticks:    db 'ticks', 0
+.str_rand:     db 'rand', 0
+.str_len:      db 'len', 0
+.str_upper:    db 'upper', 0
+.str_lower:    db 'lower', 0
+.str_reverse:  db 'reverse', 0
+.str_wait:     db 'wait', 0
+.str_cursor:   db 'cursor', 0
+.str_screen:   db 'screen', 0
+.str_uptime:   db 'uptime', 0
+.str_hex:      db 'hex', 0
+.str_ascii:    db 'ascii', 0
+.str_repeat:   db 'repeat', 0
+.str_history:  db 'history', 0
+.str_boot:     db 'boot', 0
+.str_segs:     db 'segs', 0
+.str_mode3:    db 'mode3', 0
+.str_mode50:   db 'mode50', 0
+.str_banner:   db 'banner', 0
+.str_fib:      db 'fib', 0
+.str_panic:    db 'panic', 0
+.str_divzero:  db 'divzero', 0
+.str_halt:     db 'halt', 0
 
 
-; > Исполнитель команд
+; Execute command from DS:SI
 ; Параметры:
 ;  - si: указатель на введенную строку
 execute_cmd:
@@ -59,15 +116,22 @@ execute_cmd:
     push si
 
 .compare_loop:
-    ; Загрузка символа из ввода и таблицы
+    ; Compare command names. Only the command part is case-insensitive.
     mov al, [si]
     mov ah, [bx]
 
-    ; Имя команды в таблице закончилась (\0)?
+    ; End of command name in table?
     test ah, ah
     jz .check_match
 
-    ; Сравнение символов ввода и таблицы
+    ; A-Z -> a-z for command matching.
+    cmp al, 'A'
+    jb .compare_char
+    cmp al, 'Z'
+    ja .compare_char
+    add al, 32
+
+.compare_char:
     cmp al, ah
     jne .mismatch
 
@@ -99,6 +163,8 @@ execute_cmd:
     call print
 
 .done:
+    ; Keep shell running after every normal command.
+    clc
     pop bx
     pop ax
     pop di
@@ -219,8 +285,1070 @@ cmd_echo:
 
     ret
 
-err_unknown_cmd: db '[!] Unknown command, write help for list of commands.', 0
-err_shutdown:    db '[!] PC shutdown failed! (No APM)', 0
+; > Команда версии
+cmd_ver:
+    push si
+
+    mov si, msg_version
+    call print
+
+    pop si
+    ret
+
+; > Краткая информация о системе
+cmd_about:
+    push si
+
+    mov si, msg_about
+    call print
+
+    pop si
+    ret
+
+; > Команда звукового сигнала BIOS TTY BEL
+cmd_beep:
+    push ax
+    push bx
+
+    mov ah, 0x0E
+    xor bx, bx
+    mov al, BEEP_CHAR
+    int 0x10
+
+    pop bx
+    pop ax
+    ret
+
+; > Команда вывода времени RTC/BIOS
+cmd_time:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+
+    mov ah, 0x02
+    int 0x1A
+    jc .error
+
+    mov si, msg_time
+    call print
+
+    mov al, ch        ; часы, BCD
+    call print_bcd2
+    mov al, ':'
+    call print_char_al
+    mov al, cl        ; минуты, BCD
+    call print_bcd2
+    mov al, ':'
+    call print_char_al
+    mov al, dh        ; секунды, BCD
+    call print_bcd2
+    jmp .done
+
+.error:
+    mov si, err_rtc
+    call print
+
+.done:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; > Команда вывода даты RTC/BIOS
+cmd_date:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+
+    mov ah, 0x04
+    int 0x1A
+    jc .error
+
+    mov si, msg_date
+    call print
+
+    mov al, dl        ; день, BCD
+    call print_bcd2
+    mov al, '.'
+    call print_char_al
+    mov al, dh        ; месяц, BCD
+    call print_bcd2
+    mov al, '.'
+    call print_char_al
+    mov al, ch        ; век, BCD
+    call print_bcd2
+    mov al, cl        ; год, BCD
+    call print_bcd2
+    jmp .done
+
+.error:
+    mov si, err_rtc
+    call print
+
+.done:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; > Простой калькулятор: calc <a> <+|-|*|/> <b>
+; Ограничения: ввод и результат — 16-bit unsigned (для вычитания возможен '-' перед результатом)
+cmd_calc:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+
+    call skip_spaces
+    cmp byte [si], 0
+    je .usage
+
+    call parse_uint16
+    jc .bad_syntax
+    mov [calc_left], ax
+
+    call skip_spaces
+    mov al, [si]
+    cmp al, '+'
+    je .operator_ok
+    cmp al, '-'
+    je .operator_ok
+    cmp al, '*'
+    je .operator_ok
+    cmp al, '/'
+    je .operator_ok
+    jmp .bad_syntax
+
+.operator_ok:
+    mov [calc_op], al
+    inc si
+
+    call skip_spaces
+    call parse_uint16
+    jc .bad_syntax
+    mov bx, ax
+
+    call skip_spaces
+    cmp byte [si], 0
+    jne .bad_syntax
+
+    mov ax, [calc_left]
+    mov dl, [calc_op]
+
+    cmp dl, '+'
+    je .add
+    cmp dl, '-'
+    je .sub
+    cmp dl, '*'
+    je .mul
+    cmp dl, '/'
+    je .div
+    jmp .bad_syntax
+
+.add:
+    add ax, bx
+    jc .overflow
+    jmp .print_positive
+
+.sub:
+    cmp ax, bx
+    jae .sub_positive
+
+    ; отрицательный результат: печатаем знак и модуль числа
+    mov ax, bx
+    sub ax, [calc_left]
+    mov si, msg_calc_result
+    call print
+    mov al, '-'
+    call print_char_al
+    call print_reg
+    jmp .done
+
+.sub_positive:
+    sub ax, bx
+    jmp .print_positive
+
+.mul:
+    mul bx
+    or dx, dx
+    jnz .overflow
+    jmp .print_positive
+
+.div:
+    test bx, bx
+    jz .div_zero
+    xor dx, dx
+    div bx
+    jmp .print_positive
+
+.print_positive:
+    mov si, msg_calc_result
+    call print
+    call print_reg
+    jmp .done
+
+.usage:
+    mov si, msg_calc_usage
+    call print
+    jmp .done
+
+.bad_syntax:
+    mov si, err_calc_syntax
+    call print
+    jmp .done
+
+.overflow:
+    mov si, err_calc_overflow
+    call print
+    jmp .done
+
+.div_zero:
+    mov si, err_calc_div_zero
+    call print
+
+.done:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+
+; > Ожидание клавиши и вывод ASCII/scan code
+cmd_key:
+    push ax
+    push bx
+    push si
+
+    mov si, msg_key_wait
+    call print
+
+    xor ah, ah
+    int 0x16
+    mov bx, ax
+
+    mov si, msg_key_ascii
+    call print
+    mov ax, bx
+    xor ah, ah
+    call print_reg
+
+    mov si, msg_key_scan
+    call print
+    mov ax, bx
+    mov al, ah
+    xor ah, ah
+    call print_reg
+
+    pop si
+    pop bx
+    pop ax
+    ret
+
+; > Количество BIOS timer ticks с полуночи
+cmd_ticks:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+
+    xor ah, ah
+    int 0x1A
+
+    mov bx, dx
+
+    mov si, msg_ticks_hi
+    call print
+    mov ax, cx
+    call print_reg
+
+    mov si, msg_ticks_low
+    call print
+    mov ax, bx
+    call print_reg
+
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; > Простое псевдослучайное число на базе BIOS ticks
+cmd_rand:
+    push ax
+    push cx
+    push dx
+    push si
+
+    xor ah, ah
+    int 0x1A
+
+    mov ax, dx
+    xor ax, cx
+    add ax, [rand_state]
+    rol ax, 1
+    add [rand_state], ax
+
+    mov si, msg_rand
+    call print
+    call print_reg
+
+    pop si
+    pop dx
+    pop cx
+    pop ax
+    ret
+
+; > Длина строки: len [text]
+cmd_len:
+    push ax
+    push cx
+    push si
+
+    call skip_spaces
+    xor cx, cx
+
+.loop:
+    cmp byte [si], 0
+    je .print
+    inc si
+    inc cx
+    jmp .loop
+
+.print:
+    mov si, msg_len
+    call print
+    mov ax, cx
+    call print_reg
+
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; > Печать аргументов в верхнем регистре: upper [text]
+cmd_upper:
+    push ax
+    push si
+
+    call skip_spaces
+
+.loop:
+    lodsb
+    test al, al
+    jz .done
+
+    cmp al, 'a'
+    jb .print_char
+    cmp al, 'z'
+    ja .print_char
+    sub al, 32
+
+.print_char:
+    call print_char_al
+    jmp .loop
+
+.done:
+    pop si
+    pop ax
+    ret
+
+; > Печать аргументов в нижнем регистре: lower [text]
+cmd_lower:
+    push ax
+    push si
+
+    call skip_spaces
+
+.loop:
+    lodsb
+    test al, al
+    jz .done
+
+    cmp al, 'A'
+    jb .print_char
+    cmp al, 'Z'
+    ja .print_char
+    add al, 32
+
+.print_char:
+    call print_char_al
+    jmp .loop
+
+.done:
+    pop si
+    pop ax
+    ret
+
+; > Печать аргументов задом наперед: reverse [text]
+cmd_reverse:
+    push ax
+    push bx
+    push di
+    push si
+
+    call skip_spaces
+    mov bx, si
+    mov di, si
+
+.find_end:
+    cmp byte [di], 0
+    je .print_loop_prepare
+    inc di
+    jmp .find_end
+
+.print_loop_prepare:
+    cmp di, bx
+    je .done
+    dec di
+
+.print_loop:
+    cmp di, bx
+    jb .done
+
+    mov al, [di]
+    call print_char_al
+
+    cmp di, bx
+    je .done
+    dec di
+    jmp .print_loop
+
+.done:
+    pop si
+    pop di
+    pop bx
+    pop ax
+    ret
+
+
+; Wait for any key without printing its code.
+cmd_wait:
+    push ax
+    push si
+
+    mov si, msg_wait
+    call print
+    xor ah, ah
+    int 0x16
+
+    pop si
+    pop ax
+    ret
+
+; Show current cursor position.
+cmd_cursor:
+    push ax
+    push bx
+    push dx
+    push si
+
+    mov ah, 0x03
+    xor bh, bh
+    int 0x10
+
+    mov bx, dx
+
+    mov si, msg_cursor_row
+    call print
+    xor ax, ax
+    mov al, bh
+    call print_reg
+
+    mov si, msg_cursor_col
+    call print
+    xor ax, ax
+    mov al, bl
+    call print_reg
+
+    pop si
+    pop dx
+    pop bx
+    pop ax
+    ret
+
+; Show current BIOS video mode, columns and active page.
+cmd_screen:
+    push ax
+    push bx
+    push si
+
+    mov ah, 0x0F
+    int 0x10
+    mov [screen_info_ax], ax
+    mov [screen_info_bx], bx
+
+    mov si, msg_screen_mode
+    call print
+    mov ax, [screen_info_ax]
+    xor ah, ah
+    call print_reg
+
+    mov si, msg_screen_cols
+    call print
+    mov ax, [screen_info_ax]
+    mov al, ah
+    xor ah, ah
+    call print_reg
+
+    mov si, msg_screen_page
+    call print
+    mov ax, [screen_info_bx]
+    mov al, ah
+    xor ah, ah
+    call print_reg
+
+    pop si
+    pop bx
+    pop ax
+    ret
+
+; Approximate uptime in seconds from the low BIOS tick counter.
+cmd_uptime:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+
+    xor ah, ah
+    int 0x1A
+
+    mov ax, dx
+    xor dx, dx
+    mov bx, 18
+    div bx
+
+    mov si, msg_uptime
+    call print
+    call print_reg
+
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Convert decimal number to hex: hex 4660 -> 0x1234
+cmd_hex:
+    push ax
+    push bx
+    push si
+
+    call skip_spaces
+    cmp byte [si], 0
+    je .usage
+
+    call parse_uint16
+    jc .usage
+
+    mov bx, ax
+    call skip_spaces
+    cmp byte [si], 0
+    jne .usage
+
+    mov si, msg_hex
+    call print
+    mov ax, bx
+    call print_hex16
+    jmp .done
+
+.usage:
+    mov si, msg_hex_usage
+    call print
+
+.done:
+    pop si
+    pop bx
+    pop ax
+    ret
+
+
+; Print one ASCII character by decimal code.
+; Example: ascii 65 -> A
+cmd_ascii:
+    push ax
+    push bx
+    push si
+
+    call skip_spaces
+    cmp byte [si], 0
+    je .usage
+
+    call parse_uint16
+    jc .usage
+
+    cmp ax, 255
+    ja .usage
+
+    mov bx, ax
+    call skip_spaces
+    cmp byte [si], 0
+    jne .usage
+
+    mov si, msg_ascii
+    call print
+    mov al, bl
+    call print_char_al
+    jmp .done
+
+.usage:
+    mov si, msg_ascii_usage
+    call print
+
+.done:
+    pop si
+    pop bx
+    pop ax
+    ret
+
+; Repeat text several times.
+; Example: repeat 3 hi -> hihihi
+cmd_repeat:
+    push ax
+    push cx
+    push si
+
+    call skip_spaces
+    cmp byte [si], 0
+    je .usage
+
+    call parse_uint16
+    jc .usage
+
+    test ax, ax
+    jz .done
+
+    cmp ax, 20
+    ja .too_many
+
+    mov cx, ax
+    call skip_spaces
+    cmp byte [si], 0
+    je .usage
+
+.print_loop:
+    call print
+    loop .print_loop
+    jmp .done
+
+.usage:
+    mov si, msg_repeat_usage
+    call print
+    jmp .done
+
+.too_many:
+    mov si, err_repeat_count
+    call print
+
+.done:
+    pop si
+    pop cx
+    pop ax
+    ret
+
+
+
+; Print saved command history.
+cmd_history:
+    push ax
+    push bx
+    push cx
+    push si
+
+    cmp byte [history_count], 0
+    jne .has_items
+
+    mov si, msg_history_empty
+    call print
+    jmp .done
+
+.has_items:
+    xor cx, cx
+    mov cl, [history_count]
+
+    mov al, [history_count]
+    cmp al, HISTORY_SLOTS
+    jb .start_from_zero
+
+    mov al, [history_next]
+    jmp .start_ready
+
+.start_from_zero:
+    xor al, al
+
+.start_ready:
+    mov [history_list_index], al
+    mov bx, 1
+
+.loop:
+    mov si, msg_history_item
+    call print
+
+    mov ax, bx
+    call print_reg
+
+    mov si, msg_history_sep
+    call print
+
+    mov al, [history_list_index]
+    call history_get_ptr
+    call print
+    call print_new_line
+
+    inc byte [history_list_index]
+    cmp byte [history_list_index], HISTORY_SLOTS
+    jb .index_ok
+    mov byte [history_list_index], 0
+
+.index_ok:
+    inc bx
+    loop .loop
+
+.done:
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Show BIOS boot drive number from the PC info block.
+cmd_boot:
+    push ax
+    push bx
+    push es
+    push si
+
+    xor ax, ax
+    mov es, ax
+    xor ax, ax
+    mov al, [es:PCINFO_ADDR + 2]
+    mov bx, ax
+
+    mov si, msg_boot_dec
+    call print
+    call print_reg
+
+    mov si, msg_boot_hex
+    call print
+    mov ax, bx
+    call print_hex16
+
+    pop si
+    pop es
+    pop bx
+    pop ax
+    ret
+
+; Show current segment registers.
+cmd_segs:
+    push ax
+    push si
+
+    mov si, msg_seg_cs
+    call print
+    push cs
+    pop ax
+    call print_hex16
+
+    mov si, msg_seg_ds
+    call print
+    mov ax, ds
+    call print_hex16
+
+    mov si, msg_seg_es
+    call print
+    mov ax, es
+    call print_hex16
+
+    mov si, msg_seg_ss
+    call print
+    mov ax, ss
+    call print_hex16
+
+    pop si
+    pop ax
+    ret
+
+; Reset video mode to 80x25 text mode.
+cmd_mode3:
+    push ax
+    push si
+
+    mov ax, 0x0003
+    int 0x10
+
+    mov si, msg_mode3
+    call print
+
+    pop si
+    pop ax
+    ret
+
+; Switch to 80x50 text mode using the VGA 8x8 font.
+cmd_mode50:
+    push ax
+    push bx
+    push si
+
+    mov ax, 0x0003
+    int 0x10
+
+    mov ax, 0x1112
+    xor bx, bx
+    int 0x10
+
+    mov si, msg_mode50
+    call print
+
+    pop si
+    pop bx
+    pop ax
+    ret
+
+; Print a small banner.
+cmd_banner:
+    push si
+
+    mov si, msg_banner
+    call print
+
+    pop si
+    ret
+
+; Fibonacci number: fib 10 -> 55.
+; Limit is 24 so the result fits into 16 bits.
+cmd_fib:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+
+    call skip_spaces
+    cmp byte [si], 0
+    je .usage
+
+    call parse_uint16
+    jc .usage
+
+    cmp ax, 24
+    ja .too_big
+
+    call skip_spaces
+    cmp byte [si], 0
+    jne .usage
+
+    mov cx, ax
+    xor ax, ax
+    mov bx, 1
+
+    test cx, cx
+    jz .print
+
+.loop:
+    mov dx, ax
+    add dx, bx
+    mov ax, bx
+    mov bx, dx
+    loop .loop
+
+.print:
+    mov si, msg_fib
+    call print
+    call print_reg
+    jmp .done
+
+.usage:
+    mov si, msg_fib_usage
+    call print
+    jmp .done
+
+.too_big:
+    mov si, err_fib_range
+    call print
+
+.done:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Show the panic screen manually.
+cmd_panic:
+    call debug_panic_manual
+    ret
+
+; Trigger divide-by-zero. Useful for testing the exception handler.
+cmd_divzero:
+    call debug_test_divzero
+    ret
+
+; Stop the CPU. Useful for emulator tests.
+cmd_halt:
+    mov si, msg_halt
+    call print
+    cli
+.halt_loop:
+    hlt
+    jmp .halt_loop
+
+; Skip spaces in DS:SI
+skip_spaces:
+    cmp byte [si], ' '
+    jne .done
+    inc si
+    jmp skip_spaces
+.done:
+    ret
+
+; > Парсинг беззнакового десятичного числа uint16
+; Параметры:
+;  - ds:si: строка с числом
+; Вывод:
+;  - ax: число
+;  - si: первый символ после числа
+;  - CF=0 успех, CF=1 ошибка/переполнение/нет цифр
+parse_uint16:
+    push bx
+    push cx
+    push dx
+
+    xor ax, ax
+    xor cx, cx
+
+.next_digit:
+    xor dx, dx
+    mov dl, [si]
+    cmp dl, '0'
+    jb .finish
+    cmp dl, '9'
+    ja .finish
+
+    sub dl, '0'
+    push dx
+
+    mov bx, 10
+    mul bx              ; dx:ax = ax * 10
+    or dx, dx
+    pop dx
+    jnz .error
+
+    add ax, dx
+    jc .error
+
+    inc si
+    inc cx
+    jmp .next_digit
+
+.finish:
+    test cx, cx
+    jz .error
+    clc
+    jmp .done
+
+.error:
+    stc
+
+.done:
+    pop dx
+    pop cx
+    pop bx
+    ret
+
+; > Печать одного символа из AL через BIOS TTY
+print_char_al:
+    push ax
+    push bx
+
+%ifdef KERNEL_CONSOLE
+    call console_putc
+%else
+    mov ah, 0x0E
+    xor bx, bx
+    int 0x10
+%endif
+
+    pop bx
+    pop ax
+    ret
+
+; > Печать двух BCD-цифр из AL
+print_bcd2:
+    push ax
+    push bx
+
+    mov bl, al
+    mov al, bl
+    shr al, 4
+    and al, 0x0F
+    add al, '0'
+    call print_char_al
+
+    mov al, bl
+    and al, 0x0F
+    add al, '0'
+    call print_char_al
+
+    pop bx
+    pop ax
+    ret
+
+
+; Print AX as four hexadecimal digits.
+print_hex16:
+    push ax
+    push bx
+    push cx
+
+    mov bx, ax
+    mov cx, 4
+
+.next_digit:
+    rol bx, 4
+    mov al, bl
+    and al, 0x0F
+
+    cmp al, 9
+    jbe .digit
+    add al, 'A' - 10
+    jmp .print
+
+.digit:
+    add al, '0'
+
+.print:
+    call print_char_al
+    loop .next_digit
+
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+err_unknown_cmd:      db '[!] Unknown command, write help for list of commands.', 0
+err_shutdown:         db '[!] PC shutdown failed! (No APM)', 0
+err_rtc:              db '[!] RTC/BIOS time service unavailable.', 0
+err_calc_syntax:      db '[!] Syntax: calc <number> <+|-|*|/> <number>', 0
+err_calc_overflow:    db '[!] Calculator overflow: result must fit into 16 bits.', 0
+err_calc_div_zero:    db '[!] Division by zero.', 0
+err_repeat_count:     db '[!] Repeat count must be 1..20.', 0
+err_fib_range:        db '[!] Fib argument must be 0..24.', 0
 
 ; Сообщения
 msg_help:
@@ -230,9 +1358,92 @@ msg_help:
     db '> help - Show this manual', ENTER
     db '> echo [text] - Print [text] to console', ENTER
     db '> meminfo - Display RAM configuration', ENTER
+    db '> ver - Show system version', ENTER
+    db '> about - Show short system info', ENTER
+    db '  [Tools]', ENTER
+    db '> beep - Play BIOS bell', ENTER
+    db '> date - Show RTC date', ENTER
+    db '> time - Show RTC time', ENTER
+    db '> calc A +|-|*|/ B - Calculate integer expression', ENTER
+    db '> key - Wait key and show key codes', ENTER
+    db '> ticks - Show BIOS timer ticks', ENTER
+    db '> rand - Print pseudo-random number', ENTER
+    db '> len [text] - Count text length', ENTER
+    db '> upper [text] - Print text in upper case', ENTER
+    db '> lower [text] - Print text in lower case', ENTER
+    db '> reverse [text] - Print text backwards', ENTER
+    db '> wait - Wait for any key', ENTER
+    db '> cursor - Show cursor position', ENTER
+    db '> screen - Show BIOS video mode info', ENTER
+    db '> uptime - Show approximate uptime seconds', ENTER
+    db '> hex [number] - Convert decimal to hex', ENTER
+    db '> ascii [number] - Print ASCII character', ENTER
+    db '> repeat [count] [text] - Repeat text, max 20', ENTER
+    db '> history - Show saved command history', ENTER
+    db '> boot - Show BIOS boot drive', ENTER
+    db '> segs - Show segment registers', ENTER
+    db '> mode3 - Reset 80x25 text mode', ENTER
+    db '> mode50 - Switch to 80x50 text mode', ENTER
+    db '> banner - Print Realix banner', ENTER
+    db '> fib [0-24] - Fibonacci number', ENTER
+    db '> panic - Show panic screen and halt', ENTER
+    db '> divzero - Test divide error handler', ENTER
     db '  [Power]', ENTER
     db '> reboot - Reboot PC', ENTER
-    db '> shutdown - Power off PC', 0
+    db '> shutdown - Power off PC', ENTER
+    db '> halt - Stop CPU', 0
+
+msg_version:      db 'Realix v0.06-dev / Kernel16 CLI extended', 0
+msg_about:        db 'Realix is a lightweight hybrid x86 OS: BIOS boot, FAT12, Kernel16 CLI.', 0
+msg_time:         db 'Time: ', 0
+msg_date:         db 'Date: ', 0
+msg_calc_usage:   db 'Usage: calc <number> <+|-|*|/> <number>', 0
+msg_calc_result:  db 'Result: ', 0
+msg_key_wait:     db 'Press any key...', ENTER, 0
+msg_key_ascii:    db 'ASCII: ', 0
+msg_key_scan:     db ', scan: ', 0
+msg_ticks_hi:     db 'Ticks high: ', 0
+msg_ticks_low:    db ', low: ', 0
+msg_rand:         db 'Random: ', 0
+msg_len:          db 'Length: ', 0
+msg_wait:         db 'Press any key...', 0
+msg_cursor_row:   db 'Cursor row: ', 0
+msg_cursor_col:   db ', column: ', 0
+msg_screen_mode:  db 'Video mode: ', 0
+msg_screen_cols:  db ', columns: ', 0
+msg_screen_page:  db ', page: ', 0
+msg_uptime:       db 'Uptime seconds low: ', 0
+msg_hex:          db 'Hex: 0x', 0
+msg_hex_usage:    db 'Usage: hex <number>', 0
+msg_ascii:        db 'Char: ', 0
+msg_ascii_usage:  db 'Usage: ascii <0-255>', 0
+msg_repeat_usage: db 'Usage: repeat <1-20> <text>', 0
+msg_history_empty: db 'History is empty.', 0
+msg_history_item:  db '#', 0
+msg_history_sep:   db ': ', 0
+msg_boot_dec:     db 'Boot drive: ', 0
+msg_boot_hex:     db ', hex: 0x', 0
+msg_seg_cs:       db 'CS=0x', 0
+msg_seg_ds:       db ' DS=0x', 0
+msg_seg_es:       db ' ES=0x', 0
+msg_seg_ss:       db ' SS=0x', 0
+msg_mode3:        db 'Text mode 80x25 restored.', 0
+msg_mode50:       db 'Text mode 80x50 enabled.', 0
+msg_banner:
+    db '================', ENTER
+    db ' Realix Kernel16', ENTER
+    db '================', 0
+msg_fib:          db 'Fib: ', 0
+msg_fib_usage:    db 'Usage: fib <0-24>', 0
+msg_halt:         db 'CPU halted.', 0
+
+; Variables
+calc_left:  dw 0
+calc_op:    db 0
+rand_state:      dw 0xACE1
+screen_info_ax:  dw 0
+screen_info_bx:  dw 0
+history_list_index: db 0
 
 ; Буфер ввода
 input_str: times 64 db 0


### PR DESCRIPTION
## Summary

This PR improves Kernel16 shell usability, debugging and build workflow.

## Added

- Command history with Up/Down arrows 
- PageUp/PageDown console scrollback (break)
- Basic Kernel16 panic screen
- Simple real-mode exception handlers
- QEMU debug run target with `qemu-debug.log`
- `mode50` command for 80x50 text mode
- Additional Kernel16 shell commands

## CLI improvements

- Added command history
- Added `history` command
- Added scrollback support
- Kept input editing stable by using simple append/backspace input
- Added extra utility/debug commands for testing Kernel16

## Debug improvements

- Added panic screen for Kernel16
- Added basic exception handlers for common CPU exceptions
- Added `panic` command for manual panic testing
- Added `divzero` command for divide-by-zero handler testing
- Added `run-debug` target for QEMU debugging

## Build changes

- Updated `Makefile` for Linux/WSL/MSYS2 workflow
- Added CMake build using standard tools:
  - `nasm`
  - `dd`
  - `mformat`
  - `mcopy`
  - `qemu-system-i386`

## Tested

Tested on WSL2 Arch Linux.


make clean
make
Result:



Created build/realix.img
Also tested booting the image in QEMU and using Kernel16 shell commands