### PR TITLE
Docs: Update Discord link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It supports a built-in boot switcher that lets you choose between a 16-bit Real 
 
 ## 🔗 Links & 🙌 Contributing
 - **TikTok:** [tiktok.com/@mainfox.tt](https://www.tiktok.com/@mainfox.tt)
-- **Discord:** [discord.gg/Realix](https://discord.gg/D7cATZzSAxp)
+- **Discord:** [discord.gg/Realix](https://discord.gg/D7cATZzAxp)
 
 Contributions of any kind are welcome:
 


### PR DESCRIPTION
- Replaced invalid Discord invite link (`D7cATZzSAxp` → `D7cATZzAxp`).
- Single-line change, no code affected — build testing not needed.