### PR TITLE
Kernel32: Beep on read_line buffer-full input

### DIFF
--- a/source/kernel32/src/drivers/mod.rs
+++ b/source/kernel32/src/drivers/mod.rs
@@ -5,3 +5,4 @@
 pub mod vga;
 pub mod keyboard;
 pub mod pit;
+pub mod speaker;

--- a/source/kernel32/src/drivers/pit.rs
+++ b/source/kernel32/src/drivers/pit.rs
@@ -10,7 +10,8 @@ use crate::utils::outb;
 // Порты PIT и базовая частота генератора PIT (Гц)
 const PIT_CHANNEL0: u16 = 0x40;
 const PIT_COMMAND: u16 = 0x43;
-const BASE_FREQUENCY: u32 = 1_193_182;
+// pub(crate): также используется speaker.rs (канал 2 работает от того же генератора)
+pub(crate) const BASE_FREQUENCY: u32 = 1_193_182;
 
 // Нижний предел частоты (Делитель должен влезать в 16 бит)
 const MIN_FREQUENCY: u32 = 20;

--- a/source/kernel32/src/drivers/speaker.rs
+++ b/source/kernel32/src/drivers/speaker.rs
@@ -1,0 +1,62 @@
+// © Realix > Driver: PC Speaker
+// (15.08.26) v0.1
+// ================
+// ❗️ Зависимости: pit (BASE_FREQUENCY, sleep)
+// ❗️ Использует PIT channel 2 (порты 0x42/0x43) и speaker gate (порт 0x61)
+
+// Подключение функций
+use crate::drivers::pit;
+use crate::utils::{inb, outb};
+
+// Порты PIT (канал 2) и gate-контроля спикера
+const PIT_CHANNEL2: u16 = 0x42;
+const PIT_COMMAND: u16 = 0x43;
+const SPEAKER_GATE: u16 = 0x61;
+
+// Command byte:
+// channel 2 (7-6) | low/high byte accessed (5-4)
+// square wave generator (3-1) | binary (0)
+const PIT_COMMAND_BYTE: u8 = 0b10110110;
+
+// Биты gate-порта: бит 0 - gate канала 2, бит 1 - вход динамика от PIT
+const SPEAKER_GATE_MASK: u8 = 0b11;
+
+// Параметры короткого CLI-сигнала
+const SHORT_BEEP_FREQUENCY: u32 = 1000;
+const SHORT_BEEP_DURATION_MS: u32 = 100;
+
+/// Включить PC-спикер на заданной частоте
+/// Параметры:
+///  - frequency: частота звука в Гц
+pub fn on(frequency: u32) {
+    let divisor: u16 = (pit::BASE_FREQUENCY / frequency) as u16;
+
+    unsafe {
+        // Выбираем канал 2 и загружаем делитель (сначала младший байт, потом старший)
+        outb(PIT_COMMAND, PIT_COMMAND_BYTE);
+        outb(PIT_CHANNEL2, (divisor & 0xFF) as u8);
+        outb(PIT_CHANNEL2, ((divisor >> 8) & 0xFF) as u8);
+
+        // Открываем gate канала 2 и подключаем его выход к динамику
+        let gate: u8 = inb(SPEAKER_GATE);
+        if gate & SPEAKER_GATE_MASK != SPEAKER_GATE_MASK {
+            outb(SPEAKER_GATE, gate | SPEAKER_GATE_MASK);
+        }
+    }
+}
+
+/// Выключить PC-спикер
+pub fn off() {
+    unsafe {
+        let gate: u8 = inb(SPEAKER_GATE);
+        outb(SPEAKER_GATE, gate & !SPEAKER_GATE_MASK);
+    }
+}
+
+/// Короткий звуковой сигнал обратной связи (используется, например,
+/// когда CLI отклоняет ввод — переполнение буфера строки)
+pub fn beep_short() {
+    on(SHORT_BEEP_FREQUENCY);
+    pit::sleep(SHORT_BEEP_DURATION_MS);
+    off();
+}

--- a/source/kernel32/src/shell.rs
+++ b/source/kernel32/src/shell.rs
@@ -7,6 +7,7 @@
 use crate::commands;
 use crate::drivers::keyboard::{self, read_key};
 use crate::drivers::pit;
+use crate::drivers::speaker;
 use crate::drivers::vga::{self, Color};
 use crate::utils;
 
@@ -227,6 +228,11 @@ fn read_line(history: &mut History) -> [u8; HISTORY_SLOT_SIZE] {
                 buffer[pos] = byte;
                 pos += 1;
                 vga::print_char(byte, Color::LightGray);
+            }
+            // Буфер строки заполнен (pos == INPUT_MAX) — сигнализируем об этом,
+            // а не просто молча игнорируем ввод
+            keyboard::Key::Char(byte) if (0x20..=0x7E).contains(&byte) => {
+                speaker::beep_short();
             }
             _ => {}
         }


### PR DESCRIPTION
## What changed
`read_line` in `source/kernel32/src/shell.rs` silently dropped keystrokes once `pos` hit `INPUT_MAX` (64 chars) — the guarded character arm stopped matching and the input fell through to the catch-all `_ => {}` with no feedback.

kernel32 has no BIOS to fall back on (unlike kernel16, which gets a beep for free via the `int 10h` teletype BEL character), so this adds a minimal PC speaker driver and uses it for feedback:

- `source/kernel32/src/drivers/speaker.rs` (new): PC speaker on/off via PIT channel 2 (ports `0x42`/`0x43`) + speaker gate (port `0x61`), plus a `beep_short()` helper (1000 Hz, 100 ms) for CLI feedback.
- `source/kernel32/src/drivers/pit.rs`: promoted `BASE_FREQUENCY` from private to `pub(crate)` since speaker.rs (channel 2) shares the same oscillator as the existing channel-0 timer.
- `source/kernel32/src/shell.rs`: added a new match arm in `read_line`, placed *after* the existing guarded character arm (per the issue's acceptance criteria, to avoid shadowing the working case), that calls `speaker::beep_short()` when a printable character arrives with the buffer already full.

Enter, Backspace, Escape, Up/Down history navigation, and F7 are untouched — the new arm only matches printable `Key::Char` bytes.

Closes #47

## How I tested this
- `cargo +nightly build --release --manifest-path Cargo.toml -Z json-target-spec` succeeds against the real `i386-unknown-none` target with `build-std`, with **no new warnings** introduced (all pre-existing warnings are in unrelated files).
- I was not able to run `make run` / boot the image in QEMU — my environment doesn't have `qemu-system-i386`/`mtools` available. I traced the control flow by hand (confirmed `pit::init()` runs before `shell::run()` in `main.rs`, so `pit::sleep()` inside `beep_short()` has a valid frequency to wait against) but this hasn't been boot-tested. Flagging this explicitly per the contributing guide's testing requirements — happy to iterate on review or if someone can confirm the boot behavior.