### PR TITLE
Kernel32: Add stopwatch and banner commands

### DIFF
--- a/source/kernel32/src/commands/banner.rs
+++ b/source/kernel32/src/commands/banner.rs
@@ -1,0 +1,58 @@
+// © Realix > Command: Banner
+// (15.08.26) v0.1
+// ================
+
+// Подключение функций
+use crate::drivers::vga::{self, Color, VGA_WIDTH};
+
+// Отступ текста от рамки с каждой стороны и символ рамки
+const PADDING: usize = 2;
+const BORDER_CHAR: u8 = b'*';
+
+/// Печатает переданный текст в рамке по центру строки
+/// Параметры:
+///  - text: текст для показа (без аргумента — печатается подсказка по использованию)
+pub fn run(text: &str) {
+    let text: &str = text.trim();
+
+    if text.is_empty() {
+        vga::print_line("[!] Usage: banner <text>\n", Color::Red);
+        return;
+    }
+
+    // Ограничиваем длину текста, чтобы рамка влезла в ширину экрана
+    let max_text_len: usize = VGA_WIDTH - (PADDING + 1) * 2;
+    let text: &str = &text[..text.len().min(max_text_len)];
+
+    let inner_width: usize = text.len() + PADDING * 2;
+    let border_width: usize = inner_width + 2;
+
+    print_border(border_width);
+    print_text_row(text, inner_width);
+    print_border(border_width);
+}
+
+/// Печатает верхнюю/нижнюю границу рамки
+fn print_border(width: usize) {
+    for _ in 0..width {
+        vga::print_char(BORDER_CHAR, Color::Yellow);
+    }
+    vga::new_line();
+}
+
+/// Печатает среднюю строку рамки с текстом по центру
+fn print_text_row(text: &str, inner_width: usize) {
+    let left_pad: usize = (inner_width - text.len()) / 2;
+    let right_pad: usize = inner_width - text.len() - left_pad;
+
+    vga::print_char(BORDER_CHAR, Color::Yellow);
+    for _ in 0..left_pad {
+        vga::print_char(b' ', Color::Black);
+    }
+    vga::print_line(text, Color::White);
+    for _ in 0..right_pad {
+        vga::print_char(b' ', Color::Black);
+    }
+    vga::print_char(BORDER_CHAR, Color::Yellow);
+    vga::new_line();
+}

--- a/source/kernel32/src/commands/help.rs
+++ b/source/kernel32/src/commands/help.rs
@@ -16,6 +16,8 @@ pub fn show() {
     vga::print_line("> meminfo   - Show memory information\n", Color::LightGray);
     vga::print_line("  [Fun]\n", Color::Cyan);
     vga::print_line("> matrix    - Show matrix rain\n", Color::LightGray);
+    vga::print_line("> stopwatch - Count seconds until a key is pressed\n", Color::LightGray);
+    vga::print_line("> banner [t]- Print text in a banner frame\n", Color::LightGray);
     vga::print_line("  [Power]\n", Color::Cyan);
     vga::print_line("> reboot    - Reboot PC\n", Color::LightGray);
     vga::print_line("> shutdown  - Power off PC\n", Color::LightGray);

--- a/source/kernel32/src/commands/mod.rs
+++ b/source/kernel32/src/commands/mod.rs
@@ -2,10 +2,12 @@
 // (27.07.26) v0.1
 // ================
 
+pub mod banner;
 pub mod echo;
 pub mod help;
 pub mod matrix;
 pub mod meminfo;
 pub mod reboot;
 pub mod shutdown;
+pub mod stopwatch;
 pub mod nova_ai;

--- a/source/kernel32/src/commands/stopwatch.rs
+++ b/source/kernel32/src/commands/stopwatch.rs
@@ -1,0 +1,53 @@
+// © Realix > Command: Stopwatch
+// (15.08.26) v0.1
+// ================
+
+// Подключение функций
+use crate::drivers::keyboard;
+use crate::drivers::pit;
+use crate::drivers::vga::{self, Color};
+use crate::utils;
+
+// Интервал обновления счётчика (мс)
+const UPDATE_INTERVAL_MS: u32 = 50;
+
+/// Запуск секундомера: показывает секунды в реальном времени,
+/// останов по любой нажатой клавише
+pub fn run() {
+    vga::print_line("Stopwatch started. Press any key to stop.\n", Color::LightGray);
+
+    let start: u32 = pit::get_uptime();
+
+    // Значение и ширина последней отрисованной цифры (для стирания перед перерисовкой)
+    let mut shown_value: u32 = u32::MAX;
+    let mut shown_len: usize = 0;
+
+    loop {
+        let elapsed: u32 = pit::get_uptime() - start;
+
+        // Перерисовываем число, только когда оно изменилось
+        if elapsed != shown_value {
+            for _ in 0..shown_len {
+                vga::print_backspace();
+            }
+
+            let mut str_buffer: [u8; 10] = [0u8; 10];
+            let elapsed_str: &str = utils::u32_to_dec_str(elapsed, &mut str_buffer);
+            vga::print_line(elapsed_str, Color::White);
+
+            shown_len = elapsed_str.len();
+            shown_value = elapsed;
+        }
+
+        // Выход по любой нажатой клавише (отпускания игнорируем)
+        if let Some(scancode) = keyboard::queue_pop() {
+            if scancode & keyboard::SCANCODE_RELEASE == 0 {
+                break;
+            }
+        }
+
+        pit::sleep(UPDATE_INTERVAL_MS);
+    }
+
+    vga::print_line(" s\n", Color::LightGray);
+}

--- a/source/kernel32/src/shell.rs
+++ b/source/kernel32/src/shell.rs
@@ -113,6 +113,8 @@ fn execute(input: &str) {
             vga::print_line("Entering Matrix... (Press any key to exit)\n", Color::Green);
             commands::matrix::run();
         }
+        "stopwatch" => { commands::stopwatch::run(); }
+        "banner" => { commands::banner::run(args); }
         "nova" => {
             unsafe { commands::nova_ai::BC(args); }
         }


### PR DESCRIPTION
## Что изменено

Добавлены две новые команды в CLI kernel32 (32-битное ядро):

- **`stopwatch`** — секундомер. Показывает прошедшие секунды в реальном времени (обновляется на месте, без спама новых строк) и останавливается по любой нажатой клавише. Реализован через `pit::get_uptime()` — точка отсчёта фиксируется в момент запуска команды, дальше просто вычисляется разница.
- **`banner <text>`** — печатает переданный текст по центру в рамке из `*`. Текст обрезается по ширине экрана (80 столбцов), если не помещается. Без аргумента печатает подсказку по использованию.

Обе команды добавлены в таблицу команд `shell.rs` и в список `help`.

## Почему

Эти утилиты — как `matrix`, но проще и без анимации: короткие, самодостаточные команды для CLI, которые ничего не требуют от FAT12/аллокатора (в kernel32 сейчас нет ни FAT12-драйвера, ни динамической памяти), поэтому хорошо ложатся в текущие ограничения ядра.

## Как проверялось

- `cargo +nightly build --release -Z json-target-spec` — собирается чисто, новых warning'ов не добавилось (9 существующих — не из этого PR, все в `nova_ai.rs` и `frame_allocator.rs`).
- Полная сборка `make` (bootloader + kernel16 + kernel32 + apps16) проходит без ошибок, итоговый `realix.img` — валидный загрузочный FAT12-образ (проверено через `file`).
- ⚠️ Не смог загрузочно протестировать в QEMU — в текущем окружении не было `qemu-system-x86_64`. Собранный образ появился и выглядит корректно, но интерактивную проверку самих команд в раннере я не проводил.

## Связанные issues

Не связано с конкретным issue — сделано по мотивам списка идей для вклада в проект.
