### PR TITLE
Kernel32: Add calc command

### DIFF
--- a/source/kernel32/src/commands/calc.rs
+++ b/source/kernel32/src/commands/calc.rs
@@ -1,0 +1,90 @@
+// © Realix > Command: Calculator
+// (15.08.26) v0.1
+// ================
+
+// Подключение функций
+use crate::drivers::vga::{self, Color};
+use crate::utils;
+
+/// Выполняет calc <num1> <+ - * /> <num2> (операнды - неотрицательные целые)
+/// Параметры:
+///  - args: аргументы после имени команды
+pub fn run(args: &str) {
+    let mut parts = args.split_whitespace();
+    let (a, op, b, extra) = (parts.next(), parts.next(), parts.next(), parts.next());
+
+    let (a, op, b) = match (a, op, b, extra) {
+        (Some(a), Some(op), Some(b), None) => (a, op, b),
+        _ => {
+            vga::print_line("[?] Usage: calc <num1> <+ - * /> <num2>\n", Color::LightGray);
+            return;
+        }
+    };
+
+    let a = match parse_u32(a) {
+        Some(v) => v as i64,
+        None => {
+            vga::print_line("[!] Operands must be non-negative integers.\n", Color::Red);
+            return;
+        }
+    };
+    let b = match parse_u32(b) {
+        Some(v) => v as i64,
+        None => {
+            vga::print_line("[!] Operands must be non-negative integers.\n", Color::Red);
+            return;
+        }
+    };
+
+    let result: Option<i64> = match op {
+        "+" => a.checked_add(b),
+        "-" => a.checked_sub(b),
+        "*" => a.checked_mul(b),
+        "/" => {
+            if b == 0 {
+                vga::print_line("[!] Division by zero!\n", Color::Red);
+                return;
+            }
+            Some(a / b)
+        }
+        _ => {
+            vga::print_line("[!] Unknown operator, use + - * /\n", Color::Red);
+            return;
+        }
+    };
+
+    let result = match result {
+        Some(v) if (-(u32::MAX as i64)..=u32::MAX as i64).contains(&v) => v,
+        _ => {
+            vga::print_line("[!] Result too large (overflow)\n", Color::Red);
+            return;
+        }
+    };
+
+    vga::print_line("Result: ", Color::LightGray);
+
+    let mut buf: [u8; 10] = [0u8; 10];
+    if result < 0 {
+        vga::print_line("-", Color::White);
+        vga::print_line(utils::u32_to_dec_str((-result) as u32, &mut buf), Color::White);
+    } else {
+        vga::print_line(utils::u32_to_dec_str(result as u32, &mut buf), Color::White);
+    }
+    vga::new_line();
+}
+
+/// Разбор беззнакового десятичного числа
+fn parse_u32(s: &str) -> Option<u32> {
+    if s.is_empty() {
+        return None;
+    }
+
+    let mut value: u32 = 0;
+    for byte in s.bytes() {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value = value.checked_mul(10)?.checked_add((byte - b'0') as u32)?;
+    }
+    Some(value)
+}

--- a/source/kernel32/src/commands/calc.rs
+++ b/source/kernel32/src/commands/calc.rs
@@ -16,7 +16,7 @@ pub fn run(args: &str) {
     let (a, op, b) = match (a, op, b, extra) {
         (Some(a), Some(op), Some(b), None) => (a, op, b),
         _ => {
-            vga::print_line("[?] Usage: calc <num1> <+ - * /> <num2>\n", Color::LightGray);
+            vga::print_line("[?] Usage: calc <num1> <+ - * /> <num2> (or , . ' without Shift)\n", Color::LightGray);
             return;
         }
     };
@@ -36,6 +36,14 @@ pub fn run(args: &str) {
         }
     };
 
+    // Алиасы операторов без Shift: , -> + . -> - ' -> *
+    let op = match op {
+        "," => "+",
+        "." => "-",
+        "'" => "*",
+        other => other,
+    };
+
     let result: Option<i64> = match op {
         "+" => a.checked_add(b),
         "-" => a.checked_sub(b),
@@ -48,7 +56,7 @@ pub fn run(args: &str) {
             Some(a / b)
         }
         _ => {
-            vga::print_line("[!] Unknown operator, use + - * /\n", Color::Red);
+            vga::print_line("[!] Unknown operator, use + - * / (or , . ' without Shift)\n", Color::Red);
             return;
         }
     };

--- a/source/kernel32/src/commands/help.rs
+++ b/source/kernel32/src/commands/help.rs
@@ -14,6 +14,8 @@ pub fn show() {
     vga::print_line("> echo [t]  - Print text to console\n", Color::LightGray);
     vga::print_line("> uptime    - Show uptime (seconds)\n", Color::LightGray);
     vga::print_line("> meminfo   - Show memory information\n", Color::LightGray);
+    vga::print_line("  [Numbers]\n", Color::Cyan);
+    vga::print_line("> calc <a> <+ - * /> <b> - Calculator\n", Color::LightGray);
     vga::print_line("  [Fun]\n", Color::Cyan);
     vga::print_line("> matrix    - Show matrix rain\n", Color::LightGray);
     vga::print_line("  [Power]\n", Color::Cyan);

--- a/source/kernel32/src/commands/mod.rs
+++ b/source/kernel32/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // (27.07.26) v0.1
 // ================
 
+pub mod calc;
 pub mod echo;
 pub mod help;
 pub mod matrix;

--- a/source/kernel32/src/shell.rs
+++ b/source/kernel32/src/shell.rs
@@ -99,6 +99,7 @@ fn execute(input: &str) {
         "reboot" => { commands::reboot::run() }
         "shutdown" => { commands::shutdown::run() }
         "echo" => { commands::echo::run(args) }
+        "calc" => { commands::calc::run(args); }
         "uptime" => {
             let mut str_buffer: [u8; 10] = [0u8; 10];
 


### PR DESCRIPTION
## Что изменено

Добавлена команда `calc <num1> <+ - * /> <num2>` в kernel32 — та же семантика, что и у существующего `calc` в kernel16, но на Rust:

- Операнды — неотрицательные целые (десятичные), парсятся вручную посимвольно с `checked_mul`/`checked_add` (без `alloc`/`std`, только `core`).
- Арифметика самого выражения — через `checked_add`/`checked_sub`/`checked_mul`/деление с явной проверкой на 0, вместо обычных операторов, чтобы переполнение ловилось явно (`[!] Result too large (overflow)`), а не заворачивалось молча.
- Результат вычитания может быть отрицательным — печатается со знаком `-` (как и в версии для kernel16).

Добавлена в таблицу команд `shell.rs` и в `help` (новая категория `[Numbers]`, т.к. раньше в kernel32 её не было).

## Почему

В kernel32 из "числовых" команд раньше не было вообще ничего (только `meminfo`/`uptime` по факту используют числа, но не как калькулятор) — `calc` уже есть и полезна в kernel16, разумно иметь тот же базовый инструмент в обоих ядрах.

## Как проверялось

- `cargo +nightly build --release -Z json-target-spec` — собирается чисто, новых warning'ов не добавилось (9 существующих не из этого PR).
- ⚠️ Не смог протестировать интерактивно в QEMU/VirtualBox — в текущем окружении нет эмулятора. Логика элементарная (парсинг + четыре checked-операции), но сама печать на экране (`vga::print_line` вызовы, перевод строки и т.п.) вживую не проверялась.

## Связанные issues

Не связано с конкретным issue.
