### PR TITLE
Kernel16: Calc accepts , . ' as operator aliases

### DIFF
--- a/source/kernel16/commands/calc.asm
+++ b/source/kernel16/commands/calc.asm
@@ -32,6 +32,20 @@ cmd_calc:
     lodsb
     mov [.operator], al
 
+    ; Алиасы операторов без Shift: , -> + . -> - ' -> *
+    cmp al, ','
+    jne .not_comma
+    mov byte [.operator], '+'
+.not_comma:
+    cmp al, '.'
+    jne .not_dot
+    mov byte [.operator], '-'
+.not_dot:
+    cmp al, 0x27  ; '
+    jne .not_quote
+    mov byte [.operator], '*'
+.not_quote:
+
     ; Проверка существования второго числа
     call require_arg
     jc .error_syntax
@@ -144,7 +158,7 @@ cmd_calc:
 ; Строки
 msg_result:     db 'Result: ', 0
 str_minus:      db '-', 0
-msg_calc_usage: db '[?] Usage: calc <num1> <+ - * /> <num2>', 0
-err_operator:   db '[!] Unknown operator, use + - * /', 0
+msg_calc_usage: db "[?] Usage: calc <num1> <+ - * /> <num2> (or , . ' without Shift)", 0
+err_operator:   db "[!] Unknown operator, use + - * / (or , . ' without Shift)", 0
 err_div_zero:   db '[!] Division by zero!', 0
 err_overflow:   db '[!] Result too large (overflow)', 0


### PR DESCRIPTION
## Что изменено

`calc` в kernel16 теперь принимает `,` `.` `'` как алиасы операторов вместо `+` `-` `*`:
`,` -> `+`, `.` -> `-`, `'` -> `*` (`/` не переопределялся - деление и так не требует Shift).

Разбор оператора не менялся - просто нормализация символа сразу после `lodsb`, до сравнения с `+`/`-`/`*`/`/`. Обновлены usage/error-сообщения, чтобы алиасы были видны из `calc` без аргументов и в тексте ошибки "Unknown operator".

## Почему

`+` и `*` на большинстве раскладок требуют Shift (`Shift+=`, `Shift+8`), а Shift в некоторых окружениях (например, конкретно замеченное в VirtualBox) ведёт себя нестабильно. `,` `.` `'` не требуют Shift вообще, так что калькулятором можно пользоваться даже там, где модификатор глючит. То же самое сделано параллельно и для `calc` в kernel32 (см. соответствующий PR).

## Как проверялось

- `nasm` собирает kernel16 без ошибок сборки (сама сборка ОС уже проверялась в другом PR, здесь только точечное изменение внутри `calc.asm`).
- ⚠️ Не смог протестировать интерактивно в QEMU/VirtualBox - в текущем окружении нет эмулятора. Логика тривиальна (три доп. сравнения перед существующим блоком сравнения оператора), но вживую не запускалась.

## Связанные issues

Не связано с конкретным issue.
