### PR TITLE
kernel32: port hex and fib from kernel16

### DIFF
--- a/source/kernel32/src/commands/fib.rs
+++ b/source/kernel32/src/commands/fib.rs
@@ -1,0 +1,49 @@
+// © Realix > Command: Fibonacci
+// (15.08.26) v0.1
+// ================
+
+// Подключение функций
+use crate::drivers::vga::{self, Color};
+use crate::utils;
+
+/// Выполняет fib <n>: n-ное число Фибоначчи (fib(0) = 0, fib(1) = 1)
+/// Параметры:
+///  - args: аргументы после имени команды
+pub fn run(args: &str) {
+    let mut parts = args.split_whitespace();
+    let arg = parts.next();
+    let extra = parts.next();
+
+    let n = match (arg, extra) {
+        (Some(arg), None) => utils::parse_u32(arg),
+        _ => None,
+    };
+
+    let n = match n {
+        Some(v) => v,
+        None => {
+            vga::print_line("[?] Usage: fib <n>\n", Color::LightGray);
+            return;
+        }
+    };
+
+    let mut a: u32 = 0;
+    let mut b: u32 = 1;
+
+    for _ in 0..n {
+        let next = match a.checked_add(b) {
+            Some(v) => v,
+            None => {
+                vga::print_line("[!] Fib argument too large (overflow)\n", Color::Red);
+                return;
+            }
+        };
+        a = b;
+        b = next;
+    }
+
+    let mut buf: [u8; 10] = [0u8; 10];
+    vga::print_line("Fib: ", Color::LightGray);
+    vga::print_line(utils::u32_to_dec_str(a, &mut buf), Color::White);
+    vga::new_line();
+}

--- a/source/kernel32/src/commands/help.rs
+++ b/source/kernel32/src/commands/help.rs
@@ -14,6 +14,9 @@ pub fn show() {
     vga::print_line("> echo [t]  - Print text to console\n", Color::LightGray);
     vga::print_line("> uptime    - Show uptime (seconds)\n", Color::LightGray);
     vga::print_line("> meminfo   - Show memory information\n", Color::LightGray);
+    vga::print_line("  [Numbers]\n", Color::Cyan);
+    vga::print_line("> hex <num> - <num> to hexadecimal\n", Color::LightGray);
+    vga::print_line("> fib <n>   - Nth Fibonacci number\n", Color::LightGray);
     vga::print_line("  [Fun]\n", Color::Cyan);
     vga::print_line("> matrix    - Show matrix rain\n", Color::LightGray);
     vga::print_line("  [Power]\n", Color::Cyan);

--- a/source/kernel32/src/commands/hex.rs
+++ b/source/kernel32/src/commands/hex.rs
@@ -1,0 +1,34 @@
+// © Realix > Command: Hex
+// (15.08.26) v0.1
+// ================
+
+// Подключение функций
+use crate::drivers::vga::{self, Color};
+use crate::utils;
+
+/// Выполняет hex <num>: печатает десятичное число в шестнадцатеричном виде
+/// Параметры:
+///  - args: аргументы после имени команды
+pub fn run(args: &str) {
+    let mut parts = args.split_whitespace();
+    let arg = parts.next();
+    let extra = parts.next();
+
+    let value = match (arg, extra) {
+        (Some(arg), None) => utils::parse_u32(arg),
+        _ => None,
+    };
+
+    let value = match value {
+        Some(v) => v,
+        None => {
+            vga::print_line("[?] Usage: hex <num>\n", Color::LightGray);
+            return;
+        }
+    };
+
+    let mut buf: [u8; 10] = [0u8; 10];
+    vga::print_line("Hex: ", Color::LightGray);
+    vga::print_line(utils::u32_to_hex_str(value, &mut buf), Color::White);
+    vga::new_line();
+}

--- a/source/kernel32/src/commands/mod.rs
+++ b/source/kernel32/src/commands/mod.rs
@@ -3,7 +3,9 @@
 // ================
 
 pub mod echo;
+pub mod fib;
 pub mod help;
+pub mod hex;
 pub mod matrix;
 pub mod meminfo;
 pub mod reboot;

--- a/source/kernel32/src/shell.rs
+++ b/source/kernel32/src/shell.rs
@@ -99,6 +99,8 @@ fn execute(input: &str) {
         "reboot" => { commands::reboot::run() }
         "shutdown" => { commands::shutdown::run() }
         "echo" => { commands::echo::run(args) }
+        "hex" => { commands::hex::run(args); }
+        "fib" => { commands::fib::run(args); }
         "uptime" => {
             let mut str_buffer: [u8; 10] = [0u8; 10];
 

--- a/source/kernel32/src/utils.rs
+++ b/source/kernel32/src/utils.rs
@@ -53,6 +53,26 @@ pub fn u32_to_dec_str(value: u32, str_buffer: &mut [u8; 10]) -> &str {
     core::str::from_utf8(&str_buffer[i..]).unwrap()
 }
 
+/// Разбор беззнакового десятичного числа из строки
+/// Параметры:
+///  - s: строка с числом (только цифры, без пробелов/знака)
+/// Вывод:
+///  - None, если строка пустая, содержит не только цифры, или число не влезает в u32
+pub fn parse_u32(s: &str) -> Option<u32> {
+    if s.is_empty() {
+        return None;
+    }
+
+    let mut value: u32 = 0;
+    for byte in s.bytes() {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value = value.checked_mul(10)?.checked_add((byte - b'0') as u32)?;
+    }
+    Some(value)
+}
+
 /// Запись байта в I/O-порт
 #[inline(always)]
 pub unsafe fn outb(port: u16, value: u8) {


### PR DESCRIPTION
## Что изменено

Портированы две числовые команды из kernel16 в kernel32: `hex <num>` и `fib <n>`.

- **`hex <num>`** — печатает число в шестнадцатеричном виде. В отличие от kernel16 (16-бит, `print_hex16`, 4 цифры), использует уже существующий `utils::u32_to_hex_str` и работает с полными 32-битными числами (8 цифр) — под естественную разрядность kernel32, а не буквально копирует ширину оригинала.
- **`fib <n>`** — n-ное число Фибоначчи (`fib(0)=0`, `fib(1)=1`), та же семантика, что и в kernel16. Переполнение отлавливается через `checked_add` вместо жёстко прописанного верхнего предела индекса (в kernel16 предел `24` посчитан вручную под 16-битный потолок) — для 32-битного диапазона предел другой, и `checked_add` сам корректно это определяет без риска ошибиться в ручном подсчёте.
- Добавлен `utils::parse_u32` — разбор десятичной строки в число, симметричный уже существующим `u32_to_dec_str`/`u32_to_hex_str` (перевод числа в строку). Обеим новым командам он нужен, поэтому вынесен в `utils`, а не продублирован в каждом файле.

Обе команды добавлены в `shell.rs` и в `help` (новая категория `[Numbers]`).

## Почему

Из списка идей "что можно портировать из kernel16 в kernel32" — `hex`/`fib` попадают в самую дешёвую категорию: чистая логика без завязки на BIOS/диск/железо, тривиально переносится.

## Как проверялось

- `cargo +nightly build --release -Z json-target-spec` — собирается чисто, новых warning'ов не добавилось (9 существующих не из этого PR).
- ⚠️ Не смог протестировать интерактивно в QEMU/VirtualBox — в текущем окружении нет эмулятора. Логика вручную прослежена (в т.ч. сверка семантики fib с оригиналом kernel16 по шагам), но вживую не запускалась.

## Связанные issues

Не связано с конкретным issue.
