### PR TITLE
kernel32: Fix build - stale vga::new_line() in calc

### DIFF
--- a/source/kernel32/src/commands/calc.rs
+++ b/source/kernel32/src/commands/calc.rs
@@ -78,7 +78,7 @@ pub fn run(args: &str) {
     } else {
         vga::print_line(utils::u32_to_dec_str(result as u32, &mut buf), Color::White);
     }
-    vga::new_line();
+    vga::print_new_line();
 }
 
 /// Разбор беззнакового десятичного числа


### PR DESCRIPTION
## Что изменено

`development` в текущем состоянии не собирается: `calc.rs` вызывает `vga::new_line()`, а после рефакторинга `vga.rs` (VideoOps/OPS, добавление пиксельной графики) эта функция была переименована в `print_new_line()`.

## Почему

Обнаружил при попытке собрать проект для другой задачи - без этого fix'а `cargo build` падает с E0425 на `calc.rs:81`.

## Как проверялось

- Проверил через `grep`, что других устаревших ссылок на старые имена (`vga::new_line`, `vga::new_line_if_needed`) в кодовой базе не осталось.
- `cargo +nightly build --release -Z json-target-spec` теперь собирается чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)