### PR TITLE
Initrix: Fix NASM size-specifier error

### DIFF
--- a/source/bootloader/initrix/main.asm
+++ b/source/bootloader/initrix/main.asm
@@ -62,7 +62,7 @@ main:
     movzx ax, byte [curr_drive_num]
     mov [es:PCINFO_ADDR + PCINFO_DRIVE], ax         ; 16: Номер загрузочного диска
     mov ax, 0                                       ; ++
-    mov [es:PCINFO_ADDR + PCINFO_VIDEOMODE], 0      ; 16: Номер видеорежима
+    mov word [es:PCINFO_ADDR + PCINFO_VIDEOMODE], 0 ; 16: Номер видеорежима
 
     ; Вывод заголовка загрузочного экрана
     call clear_screen


### PR DESCRIPTION
## Что изменено

`make` (полная сборка bootloader+kernel16+kernel32) сейчас падает на этапе ассемблирования `initrix.asm`: `mov [es:PCINFO_ADDR + PCINFO_VIDEOMODE], 0` без указания размера операнда - NASM не может его вывести самостоятельно, когда оба операнда не регистры (память + непосредственное значение). Добавил `word` - как в соседней записи того же поля в `switcher.asm`.

## Почему

Обнаружил при попытке собрать полный образ ОС для другой задачи (тестирование графики в kernel32) - без этого fix'а `make` не проходит дальше стадии bootloader.

## Как проверялось

- `nasm -f bin -i source source/bootloader/initrix/main.asm -o ...` теперь собирается без ошибок.
- Полная `make` дальше проходит стадию bootloader (упирается в следующий уже несвязанный шаг, если такой есть).

🤖 Generated with [Claude Code](https://claude.com/claude-code)